### PR TITLE
Remove default archive option

### DIFF
--- a/UploadDashboard/src/gov/noaa/pmel/socat/dashboard/client/SubmitForQCPage.ui.xml
+++ b/UploadDashboard/src/gov/noaa/pmel/socat/dashboard/client/SubmitForQCPage.ui.xml
@@ -15,19 +15,21 @@
 			</g:FlowPanel>
 			<g:HTML addStyleNames="{style.introhtml}" ui:field="introHtml" />
 			<g:FlowPanel addStyleNames="{style.optionsborderpanel}">
-				<g:Label addStyleNames="{style.optionsintro}" ui:field="archivePlanLabel" />
+				<g:HTML addStyleNames="{style.optionsintro}" ui:field="archivePlanHtml" />
 				<g:FlowPanel addStyleNames="{style.optionpanel}">
 					<g:RadioButton addStyleNames="{style.optionradiobutton}" 
 							name="archiveRadioGroup" ui:field="socatRadio" />
 					<g:Anchor addStyleNames="{style.optioninfoanchor}" 
 							ui:field="socatInfoAnchor" />
 				</g:FlowPanel>
+				<g:HTML addStyleNames="{style.optionaddninfo}" ui:field="socatAddnHtml" />
 				<g:FlowPanel addStyleNames="{style.optionpanel}">
 					<g:RadioButton addStyleNames="{style.optionradiobutton}" 
 							name="archiveRadioGroup" ui:field="cdiacRadio" />
 					<g:Anchor addStyleNames="{style.optioninfoanchor}" 
 							ui:field="cdiacInfoAnchor" />
 				</g:FlowPanel>
+				<g:HTML addStyleNames="{style.optionaddninfo}" ui:field="cdiacAddnHtml" />
 				<g:FlowPanel addStyleNames="{style.optionpanel}">
 					<g:RadioButton addStyleNames="{style.optionradiobutton}" 
 							name="archiveRadioGroup" ui:field="ownerRadio" />

--- a/UploadDashboard/src/gov/noaa/pmel/socat/dashboard/programs/AddDOIs.java
+++ b/UploadDashboard/src/gov/noaa/pmel/socat/dashboard/programs/AddDOIs.java
@@ -7,6 +7,7 @@ import gov.noaa.pmel.socat.dashboard.handlers.CruiseFileHandler;
 import gov.noaa.pmel.socat.dashboard.server.DashboardConfigStore;
 import gov.noaa.pmel.socat.dashboard.server.DashboardServerUtils;
 import gov.noaa.pmel.socat.dashboard.shared.DashboardCruise;
+import gov.noaa.pmel.socat.dashboard.shared.DashboardUtils;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -135,7 +136,8 @@ public class AddDOIs {
 				doi = origDOIMap.get(expocode);
 				if ( doi != null ) {
 					cruise.setOrigDoi(doi);
-					System.out.println("Updating the original-data DOI for " + expocode + " to " + doi);
+					cruise.setArchiveStatus(DashboardUtils.ARCHIVE_STATUS_ARCHIVED);
+					System.out.println("Updating the original-data DOI for " + expocode + " to " + doi + " and marking as archived");
 				}
 				try {
 					cruiseHandler.saveCruiseInfoToFile(cruise, null);


### PR DESCRIPTION
Remove the default archive option unless the user had previously selected one.  Reword "With SOCAT release" to "delay archive at this time",  Intended to reduce the number of datasets that need to be archived with the SOCAT public release - hopefully folks will submit to CDIAC beforehand.