### PR TITLE
Add expocode to archive email; complete FixWOCEColumns; better mooring detection

### DIFF
--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/handlers/ArchiveFilesBundler.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/handlers/ArchiveFilesBundler.java
@@ -51,9 +51,9 @@ public class ArchiveFilesBundler extends VersionedFileHandler {
 			"\n" +
 			"As part of submitting dataset ";
 	private static final String EMAIL_MSG_MIDDLE = 
-			" to SOCAT for QC, the SOCAT Upload Dashboard user \n";
+			" to SOCAT for QC, \nthe SOCAT Upload Dashboard user ";
 	private static final String EMAIL_MSG_END = 
-			" has requested immediate archival of the attached data and metadata. \n" +
+			" \nhas requested immediate archival of the attached data and metadata. \n" +
 			"The attached file is a ZIP file of the data and metadata, but \"" + 
 			MAILED_BUNDLE_NAME_ADDENDUM + "\" \n" +
 			"has been appended to the name for sending as an email attachment. \n" +

--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/handlers/ArchiveFilesBundler.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/handlers/ArchiveFilesBundler.java
@@ -42,15 +42,20 @@ public class ArchiveFilesBundler extends VersionedFileHandler {
 	private static final String MAILED_BUNDLE_NAME_ADDENDUM = "_from_SOCAT";
 	private static final String ENHANCED_REPORT_NAME_EXTENSION = "_SOCAT_enhanced.tsv";
 
-	private static final String EMAIL_SUBJECT_MSG = 
-			"Request for immediate archival from SOCAT dashboard user ";
+	private static final String EMAIL_SUBJECT_MSG_START = 
+			"Request for immediate archival of dataset ";
+	private static final String EMAIL_SUBJECT_MSG_MIDDLE = 
+			" from SOCAT dashboard user ";
 	private static final String EMAIL_MSG_START =
 			"Dear Archival Team, \n" +
 			"\n" +
-			"As part of submitting a dataset to SOCAT for QC, the SOCAT Upload Dashboard user \n";
+			"As part of submitting dataset ";
+	private static final String EMAIL_MSG_MIDDLE = 
+			" to SOCAT for QC, the SOCAT Upload Dashboard user \n";
 	private static final String EMAIL_MSG_END = 
 			" has requested immediate archival of the attached data and metadata. \n" +
-			"The attached file is a ZIP file of the data and metadata, but \"" + MAILED_BUNDLE_NAME_ADDENDUM + "\" \n" +
+			"The attached file is a ZIP file of the data and metadata, but \"" + 
+			MAILED_BUNDLE_NAME_ADDENDUM + "\" \n" +
 			"has been appended to the name for sending as an email attachment. \n" +
 			"\n" +
 			"Best regards, \n" +
@@ -350,7 +355,8 @@ public class ArchiveFilesBundler extends VersionedFileHandler {
 		MimeMessage msg = new MimeMessage(sessn);
 		try {
 			msg.setHeader("X-Mailer", "ArchiveFilesBundler");
-			msg.setSubject(EMAIL_SUBJECT_MSG + userRealName);
+			msg.setSubject(EMAIL_SUBJECT_MSG_START + upperExpo + 
+					EMAIL_SUBJECT_MSG_MIDDLE + userRealName);
 			msg.setSentDate(new Date());
 			// Set the addresses
 			// Mark as sent from the second cc'd address (the dashboard's);
@@ -361,7 +367,7 @@ public class ArchiveFilesBundler extends VersionedFileHandler {
 			msg.setRecipients(Message.RecipientType.CC, ccAddresses);
 			// Create the text message part
 			MimeBodyPart textMsgPart = new MimeBodyPart();
-			textMsgPart.setText(EMAIL_MSG_START + userRealName + EMAIL_MSG_END);
+			textMsgPart.setText(EMAIL_MSG_START + upperExpo + EMAIL_MSG_MIDDLE + userRealName + EMAIL_MSG_END);
 			// Create the attachment message part
 			MimeBodyPart attMsgPart = new MimeBodyPart();
 			attMsgPart.attachFile(bundleFile);

--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/handlers/UserFileHandler.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/handlers/UserFileHandler.java
@@ -461,7 +461,7 @@ public class UserFileHandler extends VersionedFileHandler {
 			DataColumnType thisColType = userColNamesToTypes.get(key);
 			if ( thisColType == null )
 				thisColType = DashboardUtils.UNKNOWN;
-			colTypes.add(thisColType);
+			colTypes.add(thisColType.duplicate());
 		}
 	}
 

--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/programs/FixWOCEColumns.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/programs/FixWOCEColumns.java
@@ -83,7 +83,7 @@ public class FixWOCEColumns {
 		String co2AtmColNameStart;
 		String woceWaterColName;
 		String woceAtmColName;
-		if ( args.length == 5 ) {
+		if ( args.length == 4 ) {
 			dupColName = args[1];
 			co2WaterColNameStart = args[2];
 			co2AtmColNameStart = args[3];

--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/programs/FixWOCEColumns.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/programs/FixWOCEColumns.java
@@ -137,14 +137,18 @@ public class FixWOCEColumns {
 							String prevColName = userColNames.get(k-1);
 							if ( prevColName.startsWith(co2WaterColNameStart) ) {
 								// New unique name for WOCE CO2 water
-								woceWaterColName = dupColName + "_" + co2WaterColNameStart;
+								woceWaterColName = (dupColName + "_" + co2WaterColNameStart)
+													.replaceAll("\\s+", "_")
+													.replaceAll("_+", "_");
 								newUserColNames.add(woceWaterColName);
 								commitMsg += "column " + dupColName + " following " + co2WaterColNameStart + 
 										" changed to " + woceWaterColName + "; ";
 							}
 							else if ( prevColName.startsWith(co2AtmColNameStart) ) {
 								// New unique name for WOCE CO2 atm
-								woceAtmColName = dupColName + "_" + co2AtmColNameStart;
+								woceAtmColName = (dupColName + "_" + co2AtmColNameStart)
+												.replaceAll("\\s+", "_")
+												.replaceAll("_+", "_");
 								newUserColNames.add(woceAtmColName);
 								commitMsg += "column " + dupColName + " following " + co2AtmColNameStart + 
 										" changed to " + woceAtmColName + "; ";
@@ -175,7 +179,7 @@ public class FixWOCEColumns {
 					ArrayList<DataColumnType> newDataColTypes = new ArrayList<DataColumnType>(numCols);
 					boolean colFound = false;
 					for (int k = 0; k < numCols; k++) {
-						if ( woceWaterColName.equals(userColNames) ) {
+						if ( woceWaterColName.equals(userColNames.get(k)) ) {
 							// Change to the WOCE CO2 water type
 							if ( ! DashboardUtils.OTHER.typeNameEquals(dataColTypes.get(k)) )
 								throw new IllegalArgumentException("WOCE CO2 water column does not have type OTHER (colNum = " + 
@@ -205,7 +209,7 @@ public class FixWOCEColumns {
 					ArrayList<DataColumnType> newDataColTypes = new ArrayList<DataColumnType>(numCols);
 					boolean colFound = false;
 					for (int k = 0; k < numCols; k++) {
-						if ( woceAtmColName.equals(userColNames) ) {
+						if ( woceAtmColName.equals(userColNames.get(k)) ) {
 							// Change to the WOCE CO2 atm type
 							if ( ! DashboardUtils.OTHER.typeNameEquals(dataColTypes.get(k)) )
 								throw new IllegalArgumentException("WOCE CO2 atm column does not have type OTHER (colNum = " + 

--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/programs/FixWOCEColumns.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/programs/FixWOCEColumns.java
@@ -4,14 +4,21 @@
 package gov.noaa.pmel.dashboard.programs;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.TreeSet;
 
 import gov.noaa.pmel.dashboard.handlers.CruiseFileHandler;
+import gov.noaa.pmel.dashboard.handlers.DatabaseRequestHandler;
+import gov.noaa.pmel.dashboard.handlers.DsgNcFileHandler;
 import gov.noaa.pmel.dashboard.server.DashboardConfigStore;
 import gov.noaa.pmel.dashboard.server.KnownDataTypes;
+import gov.noaa.pmel.dashboard.server.SocatTypes;
 import gov.noaa.pmel.dashboard.shared.DashboardCruiseWithData;
 import gov.noaa.pmel.dashboard.shared.DashboardUtils;
 import gov.noaa.pmel.dashboard.shared.DataColumnType;
+import gov.noaa.pmel.dashboard.shared.DataLocation;
+import gov.noaa.pmel.dashboard.shared.WoceEvent;
+import gov.noaa.pmel.dashboard.shared.WoceFlag;
 import gov.noaa.pmel.dashboard.shared.WoceType;
 
 /**
@@ -91,8 +98,6 @@ public class FixWOCEColumns {
 			woceAtmColName = args[2];
 		}
 
-		boolean success = true;
-
 		// Get the default dashboard configuration
 		DashboardConfigStore configStore = null;		
 		try {
@@ -103,166 +108,271 @@ public class FixWOCEColumns {
 			System.exit(1);
 		}
 		try {
+			try {
 
-			KnownDataTypes dataTypes = configStore.getKnownDataFileTypes();
-			DataColumnType woceCO2WaterType = dataTypes.getDataColumnType("WOCE_CO2_water");
-			if ( woceCO2WaterType == null )
-				throw new RuntimeException("WOCE_CO2_water not a recognized data file data column type");
-			DataColumnType woceCO2AtmType = dataTypes.getDataColumnType("WOCE_CO2_atm");
-			if ( woceCO2AtmType == null )
-				throw new RuntimeException("WOCE_CO2_atm not a recognized data file data column type");
+				KnownDataTypes dataTypes = configStore.getKnownDataFileTypes();
+				DataColumnType woceCO2WaterType = dataTypes.getDataColumnType("WOCE_CO2_water");
+				if ( woceCO2WaterType == null )
+					throw new RuntimeException("WOCE_CO2_water not a recognized data file data column type");
+				DataColumnType woceCO2AtmType = dataTypes.getDataColumnType("WOCE_CO2_atm");
+				if ( woceCO2AtmType == null )
+					throw new RuntimeException("WOCE_CO2_atm not a recognized data file data column type");
 
-			CruiseFileHandler cruiseHandler = configStore.getCruiseFileHandler();
-			DashboardCruiseWithData cruiseData = cruiseHandler.getCruiseDataFromFiles(expocode, 0, -1);
+				CruiseFileHandler cruiseHandler = configStore.getCruiseFileHandler();
+				DashboardCruiseWithData cruiseData = cruiseHandler.getCruiseDataFromFiles(expocode, 0, -1);
 
-			String commitMsg = "";
+				String commitMsg = "";
 
-			// If needed, make unique WOCE column names
-			if ( dupColName != null ) {
-				ArrayList<String> userColNames = cruiseData.getUserColNames();
-				int numCols = userColNames.size();
-				ArrayList<String> newUserColNames = new ArrayList<String>(numCols);
-				// First column name cannot be made unique, and should not be WOCE in this scheme, 
-				// because there is no previous column
-				newUserColNames.add(userColNames.get(0));
-				for (int k = 1; k < numCols; k++) {
-					String thisColName = userColNames.get(k);
-					if ( dupColName.equals(thisColName) ) {
-						String prevColName = userColNames.get(k-1);
-						if ( prevColName.startsWith(co2WaterColNameStart) ) {
-							// New unique name for WOCE CO2 water
-							woceWaterColName = dupColName + "_" + co2WaterColNameStart;
-							newUserColNames.add(woceWaterColName);
-							commitMsg += "column " + dupColName + " following " + co2WaterColNameStart + 
-									" changed to " + woceWaterColName + "; ";
-						}
-						else if ( prevColName.startsWith(co2AtmColNameStart) ) {
-							// New unique name for WOCE CO2 atm
-							woceAtmColName = dupColName + "_" + co2AtmColNameStart;
-							newUserColNames.add(woceAtmColName);
-							commitMsg += "column " + dupColName + " following " + co2AtmColNameStart + 
-									" changed to " + woceAtmColName + "; ";
+				// If needed, make unique WOCE column names
+				if ( dupColName != null ) {
+					ArrayList<String> userColNames = cruiseData.getUserColNames();
+					int numCols = userColNames.size();
+					ArrayList<String> newUserColNames = new ArrayList<String>(numCols);
+					// First column name cannot be made unique, and should not be WOCE in this scheme, 
+					// because there is no previous column
+					newUserColNames.add(userColNames.get(0));
+					for (int k = 1; k < numCols; k++) {
+						String thisColName = userColNames.get(k);
+						if ( dupColName.equals(thisColName) ) {
+							String prevColName = userColNames.get(k-1);
+							if ( prevColName.startsWith(co2WaterColNameStart) ) {
+								// New unique name for WOCE CO2 water
+								woceWaterColName = dupColName + "_" + co2WaterColNameStart;
+								newUserColNames.add(woceWaterColName);
+								commitMsg += "column " + dupColName + " following " + co2WaterColNameStart + 
+										" changed to " + woceWaterColName + "; ";
+							}
+							else if ( prevColName.startsWith(co2AtmColNameStart) ) {
+								// New unique name for WOCE CO2 atm
+								woceAtmColName = dupColName + "_" + co2AtmColNameStart;
+								newUserColNames.add(woceAtmColName);
+								commitMsg += "column " + dupColName + " following " + co2AtmColNameStart + 
+										" changed to " + woceAtmColName + "; ";
+							}
+							else {
+								// Some other WOCE flag; copy over the existing (duplicate) name
+								newUserColNames.add(thisColName);
+							}
 						}
 						else {
-							// Some other WOCE flag; copy over the existing (duplicate) name
+							// Copy over the existing name
 							newUserColNames.add(thisColName);
 						}
 					}
-					else {
-						// Copy over the existing name
-						newUserColNames.add(thisColName);
-					}
-				}
-				if ( woceWaterColName.isEmpty() && woceAtmColName.isEmpty() )
-					throw new IllegalArgumentException("No duplicated WOCE column names changed\n" +
-							"No changes made to this dataset.");
+					if ( woceWaterColName.isEmpty() && woceAtmColName.isEmpty() )
+						throw new IllegalArgumentException("No duplicated WOCE column names changed\n" +
+								"No changes made to this dataset.");
 
-				// Update the names in the DashboardCruiseWithData object
-				cruiseData.setUserColNames(newUserColNames);
-			}
-			
-			// Add the WOCE flags given in the named columns
-			if ( ! woceWaterColName.isEmpty() ) {
-				ArrayList<String> userColNames = cruiseData.getUserColNames();
+					// Update the names in the DashboardCruiseWithData object
+					cruiseData.setUserColNames(newUserColNames);
+				}
+
+				// Add the WOCE flags given in the named columns
+				if ( ! woceWaterColName.isEmpty() ) {
+					ArrayList<String> userColNames = cruiseData.getUserColNames();
+					ArrayList<DataColumnType> dataColTypes = cruiseData.getDataColTypes();
+					int numCols = dataColTypes.size();
+					ArrayList<DataColumnType> newDataColTypes = new ArrayList<DataColumnType>(numCols);
+					boolean colFound = false;
+					for (int k = 0; k < numCols; k++) {
+						if ( woceWaterColName.equals(userColNames) ) {
+							// Change to the WOCE CO2 water type
+							if ( ! DashboardUtils.OTHER.typeNameEquals(dataColTypes.get(k)) )
+								throw new IllegalArgumentException("WOCE CO2 water column does not have type OTHER (colNum = " + 
+										Integer.toString(k+1) + ", type = " + dataColTypes.get(k).getDisplayName() + ")\n" +
+										"No changes made to this dataset.");
+							if ( colFound )
+								throw new IllegalArgumentException("More than one WOCE CO2 water column named " + 
+										woceWaterColName + "\nNo changes made to this dataset.");
+							newDataColTypes.add(woceCO2WaterType);
+							colFound = true;
+						}
+						else {
+							// Copy over the existing data type
+							newDataColTypes.add(dataColTypes.get(k));
+						}
+					}
+					if ( ! colFound )
+						throw new IllegalArgumentException("No column found with name " +
+								woceWaterColName + "\nNo changes made to this dataset.");
+					commitMsg += "type of column " + woceWaterColName + " changed to WOCE_CO2_water; ";
+					cruiseData.setDataColTypes(newDataColTypes);
+				}
+				if ( ! woceAtmColName.isEmpty() ) {
+					ArrayList<String> userColNames = cruiseData.getUserColNames();
+					ArrayList<DataColumnType> dataColTypes = cruiseData.getDataColTypes();
+					int numCols = dataColTypes.size();
+					ArrayList<DataColumnType> newDataColTypes = new ArrayList<DataColumnType>(numCols);
+					boolean colFound = false;
+					for (int k = 0; k < numCols; k++) {
+						if ( woceAtmColName.equals(userColNames) ) {
+							// Change to the WOCE CO2 atm type
+							if ( ! DashboardUtils.OTHER.typeNameEquals(dataColTypes.get(k)) )
+								throw new IllegalArgumentException("WOCE CO2 atm column does not have type OTHER (colNum = " + 
+										Integer.toString(k+1) + ", type = " + dataColTypes.get(k).getDisplayName() + ")\n" +
+										"No changes made to this dataset.");
+							if ( colFound )
+								throw new IllegalArgumentException("More than one WOCE CO2 atm column named " + 
+										woceAtmColName + "\nNo changes made to this dataset.");
+							newDataColTypes.add(woceCO2AtmType);
+							colFound = true;
+						}
+						else {
+							// Copy over the existing data type
+							newDataColTypes.add(dataColTypes.get(k));
+						}
+					}
+					if ( ! colFound )
+						throw new IllegalArgumentException("No column found with name " +
+								woceAtmColName + "\nNo changes made to this dataset.");
+					commitMsg += "type of column " + woceAtmColName + " changed to WOCE_CO2_atm; ";
+					cruiseData.setDataColTypes(newDataColTypes);
+				}
+
+				if ( commitMsg.isEmpty() )
+					throw new IllegalArgumentException("No changes made to this dataset.");
+
+				// Assign any user-provided WOCE-3 and WOCE-4 flags
+				TreeSet<WoceType> woceFours = new TreeSet<WoceType>();
+				TreeSet<WoceType> woceThrees = new TreeSet<WoceType>();
 				ArrayList<DataColumnType> dataColTypes = cruiseData.getDataColTypes();
 				int numCols = dataColTypes.size();
-				ArrayList<DataColumnType> newDataColTypes = new ArrayList<DataColumnType>(numCols);
-				boolean colFound = false;
 				for (int k = 0; k < numCols; k++) {
-					if ( woceWaterColName.equals(userColNames) ) {
-						// Change to the WOCE CO2 water type
-						if ( ! DashboardUtils.OTHER.typeNameEquals(dataColTypes.get(k)) )
-							throw new IllegalArgumentException("WOCE CO2 water column does not have type OTHER (colNum = " + 
-									Integer.toString(k+1) + ", type = " + dataColTypes.get(k).getDisplayName() + ")\n" +
-									"No changes made to this dataset.");
-						if ( colFound )
-							throw new IllegalArgumentException("More than one WOCE CO2 water column named " + 
-									woceWaterColName + "\nNo changes made to this dataset.");
-						newDataColTypes.add(woceCO2WaterType);
-						colFound = true;
-					}
-					else {
-						// Copy over the existing data type
-						newDataColTypes.add(dataColTypes.get(k));
+					DataColumnType colType = dataColTypes.get(k);
+					if ( ! colType.isWoceType() )
+						continue;
+					for (int rowIdx = 0; rowIdx < cruiseData.getNumDataRows(); rowIdx++) {
+						try {
+							int value = Integer.parseInt(cruiseData.getDataValues().get(rowIdx).get(k));
+							if ( value == 4 )
+								woceFours.add(new WoceType(colType.getVarName(), null, rowIdx));
+							else if ( value == 3 )
+								woceThrees.add(new WoceType(colType.getVarName(), null, rowIdx));
+							// Only handle 3 and 4
+						} catch (NumberFormatException ex) {
+							// Assuming a missing value
+						}
 					}
 				}
-				if ( ! colFound )
-					throw new IllegalArgumentException("No column found with name " +
-							woceWaterColName + "\nNo changes made to this dataset.");
-				commitMsg += "type of column " + woceWaterColName + " changed to WOCE_CO2_water; ";
-				cruiseData.setDataColTypes(newDataColTypes);
-			}
-			if ( ! woceAtmColName.isEmpty() ) {
-				ArrayList<String> userColNames = cruiseData.getUserColNames();
-				ArrayList<DataColumnType> dataColTypes = cruiseData.getDataColTypes();
-				int numCols = dataColTypes.size();
-				ArrayList<DataColumnType> newDataColTypes = new ArrayList<DataColumnType>(numCols);
-				boolean colFound = false;
-				for (int k = 0; k < numCols; k++) {
-					if ( woceAtmColName.equals(userColNames) ) {
-						// Change to the WOCE CO2 atm type
-						if ( ! DashboardUtils.OTHER.typeNameEquals(dataColTypes.get(k)) )
-							throw new IllegalArgumentException("WOCE CO2 atm column does not have type OTHER (colNum = " + 
-									Integer.toString(k+1) + ", type = " + dataColTypes.get(k).getDisplayName() + ")\n" +
-									"No changes made to this dataset.");
-						if ( colFound )
-							throw new IllegalArgumentException("More than one WOCE CO2 atm column named " + 
-									woceAtmColName + "\nNo changes made to this dataset.");
-						newDataColTypes.add(woceCO2AtmType);
-						colFound = true;
-					}
-					else {
-						// Copy over the existing data type
-						newDataColTypes.add(dataColTypes.get(k));
-					}
+				cruiseData.setUserWoceFours(woceFours);
+				cruiseData.setUserWoceThrees(woceThrees);
+
+				// Save the new data column names and types to file
+				cruiseHandler.saveCruiseInfoToFile(cruiseData, commitMsg);
+				cruiseHandler.saveCruiseDataToFile(cruiseData, commitMsg);
+
+				// Ordered set of all WOCE flags for this dataset
+				TreeSet<WoceFlag> woceFlagSet = new TreeSet<WoceFlag>();
+
+				// Create WOCE flags for any PI-provided WOCE-3 flags 
+				for ( WoceType uwoce : woceThrees ) {
+					// Do not associate any data column with this WOCE flag 
+					// (the previous column is not the problematic data for the WOCE)
+					WoceFlag info = new WoceFlag(uwoce.getWoceName(), null, uwoce.getRowIndex());
+					info.setFlag(DashboardUtils.WOCE_QUESTIONABLE);
+					// Assume there are no user-provided comments for these WOCE flags
+					info.setComment(DashboardUtils.PI_PROVIDED_WOCE_COMMENT_START + "3 flag");
+					woceFlagSet.add(info);
 				}
-				if ( ! colFound )
-					throw new IllegalArgumentException("No column found with name " +
-							woceAtmColName + "\nNo changes made to this dataset.");
-				commitMsg += "type of column " + woceAtmColName + " changed to WOCE_CO2_atm; ";
-				cruiseData.setDataColTypes(newDataColTypes);
-			}
 
-			if ( commitMsg.isEmpty() )
-				throw new IllegalArgumentException("No changes made to this dataset.");
+				// Create WOCE flags for any PI-provided WOCE-4 flags 
+				for ( WoceType uwoce : woceFours ) {
+					// Do not associate any data column with this WOCE flag 
+					// (the previous column is not the problematic data for the WOCE)
+					WoceFlag info = new WoceFlag(uwoce.getWoceName(), null, uwoce.getRowIndex());
+					info.setFlag(DashboardUtils.WOCE_BAD);
+					// Assume there are no user-provided comments for these WOCE flags
+					info.setComment(DashboardUtils.PI_PROVIDED_WOCE_COMMENT_START + "4 flag");
+					woceFlagSet.add(info);
+				}
 
-			// Assign any user-provided WOCE-3 and WOCE-4 flags
-			TreeSet<WoceType> woceFours = new TreeSet<WoceType>();
-			TreeSet<WoceType> woceThrees = new TreeSet<WoceType>();
-			ArrayList<DataColumnType> dataColTypes = cruiseData.getDataColTypes();
-			int numCols = dataColTypes.size();
-			for (int k = 0; k < numCols; k++) {
-				DataColumnType colType = dataColTypes.get(k);
-				if ( ! colType.isWoceType() )
-					continue;
-				for (int rowIdx = 0; rowIdx < cruiseData.getNumDataRows(); rowIdx++) {
+				if ( ! woceFlagSet.isEmpty() ) {
+					// List of WOCE events (up to four events - WOCE-3 and/or WOCE-4 on CO2_water and/or CO2_atm)
+					ArrayList<WoceEvent> woceList = new ArrayList<WoceEvent>();
+
+					String version = cruiseData.getVersion();
+					Date now = new Date();
+
+					// Get the longitudes, latitude, times, and regions IDs 
+					// from the full-data DSG file for this cruise
+					double[][] lonlattime;
+					char[] regionIDs;
 					try {
-						int value = Integer.parseInt(cruiseData.getDataValues().get(rowIdx).get(k));
-						if ( value == 4 )
-							woceFours.add(new WoceType(colType.getVarName(), null, rowIdx));
-						else if ( value == 3 )
-							woceThrees.add(new WoceType(colType.getVarName(), null, rowIdx));
-						// Only handle 3 and 4
-					} catch (NumberFormatException ex) {
-						// Assuming a missing value
+						DsgNcFileHandler dsgHandler = configStore.getDsgNcFileHandler();
+						lonlattime = dsgHandler.readLonLatTimeDataValues(expocode);
+						regionIDs = dsgHandler.readCharVarDataValues(expocode, SocatTypes.REGION_ID.getVarName());
+					} catch ( Exception ex ) {
+						throw new IllegalArgumentException("cannot read DSG file: " + ex.getMessage() + 
+								"\nOriginal data properties file changed but no WOCE flags changed");
+					}
+					double[] longitudes = lonlattime[0];
+					double[] latitudes = lonlattime[1];
+					double[] times = lonlattime[2];
+
+					String lastWoceName = null;
+					Character lastFlag = null;
+					String lastComment = null;
+					ArrayList<DataLocation> locations = null;
+					for ( WoceFlag info : woceFlagSet ) {
+
+						// Check if a new WOCE event is needed
+						String woceName = info.getWoceName();
+						Character flag = info.getFlag();
+						String comment = info.getComment();
+						if ( ( ! woceName.equals(lastWoceName) ) ||
+								( ! flag.equals(lastFlag) ) ||
+								( ! comment.equals(lastComment) ) ) {
+							lastWoceName = woceName;
+							lastFlag = flag;
+							lastComment = comment;
+
+							WoceEvent woceEvent = new WoceEvent();
+							woceEvent.setWoceName(woceName);
+							woceEvent.setExpocode(expocode);
+							woceEvent.setVersion(version);
+							woceEvent.setFlag(flag);
+							woceEvent.setFlagDate(now);
+							woceEvent.setUsername(DashboardUtils.SANITY_CHECKER_USERNAME);
+							woceEvent.setRealname(DashboardUtils.SANITY_CHECKER_REALNAME);
+							woceEvent.setComment(comment);
+
+							// Directly modify the locations ArrayList in this object
+							locations = woceEvent.getLocations();
+							woceList.add(woceEvent);
+						}
+
+						// Add a location for the current WOCE event
+						DataLocation dataLoc = new DataLocation();
+						int rowIdx = info.getRowIndex();
+						dataLoc.setRowNumber(rowIdx + 1);
+						dataLoc.setDataDate(new Date(Math.round(times[rowIdx] * 1000.0)));
+						dataLoc.setLatitude(latitudes[rowIdx]);
+						dataLoc.setLongitude(longitudes[rowIdx]);
+						dataLoc.setRegionID(regionIDs[rowIdx]);
+						locations.add(dataLoc);
+					}
+
+					// Add these WOCE events to the database
+					try {
+						DatabaseRequestHandler databaseHandler = configStore.getDatabaseRequestHandler();
+						for ( WoceEvent woceEvent : woceList ) {
+							databaseHandler.addWoceEvent(woceEvent);
+						}
+					} catch ( Exception ex ) {
+						throw new IllegalArgumentException("Unable to add a WOCE flag to the database: " + ex.getMessage() + 
+								"\nOriginal data properties file changed; any previous WOCE flags added to database");
 					}
 				}
+
+			} finally {
+				DashboardConfigStore.shutdown();
 			}
-			cruiseData.setUserWoceFours(woceFours);
-			cruiseData.setUserWoceThrees(woceThrees);
-
-			// Save the new data column names and types to file
-			cruiseHandler.saveCruiseInfoToFile(cruiseData, commitMsg);
-			cruiseHandler.saveCruiseDataToFile(cruiseData, commitMsg);
-
-			// TODO: Create WOCE Events for these new WOCE columns and add to database
-			
-		} finally {
-			DashboardConfigStore.shutdown();
+		} catch ( Exception ex ) {
+			System.err.println("ERROR - " + ex.getMessage());
+			ex.printStackTrace();
+			System.exit(1);
 		}
 
-		if ( ! success )
-			System.exit(1);
 		System.exit(0);
 	}
 

--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/server/DashboardServerUtils.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/server/DashboardServerUtils.java
@@ -110,9 +110,11 @@ public class DashboardServerUtils {
 	 * NODC codes (all upper-case) for Moorings and Fixed Buoys 
 	 */
 	private static final HashSet<String> FIXED_PLATFORM_NODC_CODES = 
-			new HashSet<String>(Arrays.asList("067F", "147F", "187F", "247F", 
-					"267F", "297F", "3119", "3164", "317F", "33GO", "33TT", 
-					"357F", "48MB", "497F", "747F", "767F", "907F", "GH7F"));
+			new HashSet<String>(Arrays.asList("067F", "08FS", "09FS", "147F", 
+					"187F", "18FX", "247F", "24FS", "267F", "26FS", "297F", 
+					"3119", "3164", "317F", "32FS", "33GO", "33TT", "357F", 
+					"48MB", "497F", "49FS", "747F", "74FS", "767F", "77FS", 
+					"907F", "91FS", "GH7F"));
 
 	/**
 	 * NODC codes (all upper-case) for Drifting Buoys 
@@ -198,18 +200,18 @@ public class DashboardServerUtils {
 	 * otherwise it is assumed to be a ship.
 	 * 
 	 * @param expocode
-	 * 		expocode of the dataset
+	 * 		expocode of the dataset; cannot be null
 	 * @param platformName
-	 * 		platform name for the dataset
+	 * 		platform name for the dataset; cannot be null
 	 * @return
 	 * 		one of "Mooring", "Drifting Buoy", or "Ship"
 	 */
 	public static String guessPlatformType(String expocode, String platformName) {
-		if ( "Mooring".equalsIgnoreCase(platformName) )
+		if ( platformName.toUpperCase().contains("MOORING") )
 			return "Mooring";
-		if ( "Drifting Buoy".equalsIgnoreCase(platformName) )
+		if ( platformName.toUpperCase().contains("DRIFTING BUOY") )
 			return "Drifting Buoy";
-		if ( "Bouy".equalsIgnoreCase(platformName) )
+		if ( platformName.toUpperCase().contains("BUOY") )
 			return "Mooring";
 
 		String nodc = expocode.substring(0, 4).toUpperCase();


### PR DESCRIPTION
Expocode added to archive email subject line and message to make it clearer there are differences when multiple datasets sent for archival at one time.

Added more mooring expocodes.  Added check for "mooring", "drifting buoy", or "buoy" in the name (rather than being exactly the name).

Finish FixWOCEColumns - as used to pull in the PMEL mooring dataset WOCE columns.

Very minor bug fix - assign a duplicate of the DataColumnType (very minor since currently only one of any given type other than "OTHER" is allowed).