### PR TITLE
Changes to automate PI name and organization corrections

### DIFF
--- a/OmeMetadata/src/uk/ac/uea/socat/omemetadata/OmeMetadata.java
+++ b/OmeMetadata/src/uk/ac/uea/socat/omemetadata/OmeMetadata.java
@@ -843,7 +843,30 @@ public class OmeMetadata {
 			storeValue(name, value, lineCount);
 		}
 	}
-	
+
+	/**
+	 * Clears the line of composite variables
+	 * 
+	 * @param name
+	 * 		name of the composite variables list to clear
+	 * @throws OmeMetadataException
+	 * 		if the composite variables list name is not recognized
+	 */
+	public void clearCompositeValueList(String name) throws OmeMetadataException {
+		if (name.equalsIgnoreCase(INVESTIGATOR_COMP_NAME)) {
+			investigators.clear();
+		}
+		else if (name.equalsIgnoreCase(VARIABLE_COMP_NAME)) {
+			variablesInfo.clear();
+		}
+		else if (name.equalsIgnoreCase(OTHER_SENSOR_COMP_NAME)) {
+			otherSensors.clear();
+		}
+		else {
+			throw new OmeMetadataException(-1, "Unrecognized composite entry '" + name + "'");
+		}
+	}
+
 	public void storeCompositeValue(String name, Properties values, int line) throws OmeMetadataException, BadEntryNameException, InvalidConflictException {
 		
 		OMECompositeVariable compositeVar = null;

--- a/UploadDashboard/.settings/.gitignore
+++ b/UploadDashboard/.settings/.gitignore
@@ -1,1 +1,0 @@
-/org.eclipse.jdt.core.prefs

--- a/UploadDashboard/.settings/org.eclipse.jdt.core.prefs
+++ b/UploadDashboard/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/actions/CruiseSubmitter.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/actions/CruiseSubmitter.java
@@ -237,6 +237,14 @@ public class CruiseSubmitter {
 					logger.debug("Generating the full-data DSG file for " + expocode);
 					dsgNcHandler.saveCruise(omeMData, cruiseData, socatVersionStatus, flag.toString());
 
+					// Pause a bit to make sure the OS is done with the full-data DSG file.
+					// (Guessing at the cause of a very rare error message.)
+					try {
+						Thread.sleep(100);
+					} catch ( Exception ex ) {
+						; // Ignore
+					}
+
 					// Generate the decimated-data DSG file from the full-data DSG file
 					logger.debug("Generating the decimated-data DSG file for " + expocode);
 					dsgNcHandler.decimateCruise(expocode);

--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/handlers/ArchiveFilesBundler.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/handlers/ArchiveFilesBundler.java
@@ -43,17 +43,17 @@ public class ArchiveFilesBundler extends VersionedFileHandler {
 	private static final String ENHANCED_REPORT_NAME_EXTENSION = "_SOCAT_enhanced.tsv";
 
 	private static final String EMAIL_SUBJECT_MSG_START = 
-			"Request for immediate archival of dataset ";
+			"Request for OCADS archival of dataset ";
 	private static final String EMAIL_SUBJECT_MSG_MIDDLE = 
 			" from SOCAT dashboard user ";
 	private static final String EMAIL_MSG_START =
-			"Dear Archival Team, \n" +
+			"Dear OCADS Archival Team, \n" +
 			"\n" +
 			"As part of submitting dataset ";
 	private static final String EMAIL_MSG_MIDDLE = 
 			" to SOCAT for QC, \nthe SOCAT Upload Dashboard user ";
 	private static final String EMAIL_MSG_END = 
-			" \nhas requested immediate archival of the attached data and metadata. \n" +
+			" \nhas requested immediate OCADS archival of the attached data and metadata. \n" +
 			"The attached file is a ZIP file of the data and metadata, but \"" + 
 			MAILED_BUNDLE_NAME_ADDENDUM + "\" \n" +
 			"has been appended to the name for sending as an email attachment. \n" +

--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/programs/FixPINamesOrgs.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/programs/FixPINamesOrgs.java
@@ -1,0 +1,296 @@
+/**
+ * 
+ */
+package gov.noaa.pmel.dashboard.programs;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Properties;
+import java.util.TreeSet;
+
+import org.jdom2.Document;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+
+import gov.noaa.pmel.dashboard.handlers.MetadataFileHandler;
+import gov.noaa.pmel.dashboard.server.DashboardConfigStore;
+import gov.noaa.pmel.dashboard.server.DashboardServerUtils;
+import gov.noaa.pmel.dashboard.shared.DashboardUtils;
+
+import uk.ac.uea.socat.omemetadata.OmeMetadata;
+
+/**
+ * Updates dashboard's OME.xml from PI name corrections and organization names 
+ * given in tab-separated-values files.
+ * 
+ * @author Karl Smith
+ */
+public class FixPINamesOrgs {
+
+	HashMap<String,ArrayList<String>> nameFixMap;
+	HashMap<String,String> nameOrgMap;
+
+	/**
+	 * Corrects names of PIs and organizations in OME metadata
+	 * 
+	 * @param piNameFixesFile
+	 * 		TSV file of error names and corrects; 
+	 * 		each line consists of the error 'name', a tab, and the correct name(s);
+	 * 		multiple correct names are separated by semicolons
+	 * @param piNameOrgFile
+	 * 		TSV file of (correct) PI names and organizations;
+	 * 		each line consists of the PI name, a tab, and the PI organization
+	 * @throws IllegalArgumentException
+	 * 		if problems reading either of the files
+	 */
+	public FixPINamesOrgs(File piNameFixesFile, File piNameOrgFile) throws IllegalArgumentException {
+		BufferedReader reader;
+
+		nameFixMap = new HashMap<String,ArrayList<String>>();
+		try {
+			reader = new BufferedReader(new FileReader(piNameFixesFile));
+			try {
+				String dataline = reader.readLine();
+				while ( dataline != null ) {
+
+					String[] pieces = dataline.trim().split("\\t");
+					if ( pieces.length != 2 ) 
+						throw new IllegalArgumentException("not two values separated by a tab in '" + dataline + "'");
+					String errName = pieces[0].trim();
+					if ( errName.isEmpty() )
+						throw new IllegalArgumentException("empty error name value in '" + dataline + "'");
+					String[] fixNames = pieces[1].split(";");
+					ArrayList<String> fixList = new ArrayList<String>(fixNames.length);
+					for ( String fix : fixNames ) {
+						fix = fix.trim();
+						if ( fix.isEmpty() )
+							throw new IllegalArgumentException("empty name correction in '" + dataline + "'");
+						fixList.add(fix);
+					}
+					if ( nameFixMap.put(errName, fixList) != null )
+						throw new IllegalArgumentException("more than one correction for '" + errName + "'");
+
+					dataline = reader.readLine();
+				}
+			} finally {
+				reader.close();
+			}
+		} catch ( Exception ex ) {
+			throw new IllegalArgumentException("Problems with " + piNameFixesFile.getPath() + ": " + ex.getMessage(), ex);
+		}
+
+		nameOrgMap = new HashMap<String,String>();
+		try {
+			reader = new BufferedReader(new FileReader(piNameOrgFile));
+			try {
+				String dataline = reader.readLine();
+				while ( dataline != null ) {
+
+					String[] pieces = dataline.trim().split("\\t");
+					if ( pieces.length != 2 ) 
+						throw new IllegalArgumentException("not two values separated by a tab in '" + dataline + "'");
+					String piName = pieces[0].trim();
+					if ( piName.isEmpty() )
+						throw new IllegalArgumentException("empty PI name in '" + dataline + "'");
+					String piOrg = pieces[1].trim();
+					if ( piOrg.isEmpty() )
+						throw new IllegalArgumentException("empty PI organization in '" + dataline + "'");
+					nameOrgMap.put(piName, piOrg);
+
+					dataline = reader.readLine();
+				}
+			} finally {
+				reader.close();
+			}
+		} catch ( Exception ex ) {
+			throw new IllegalArgumentException("Problems with " + piNameOrgFile.getPath() + ": " + ex.getMessage(), ex);
+		}
+	}
+
+	/**
+	 * Correct the PI name(s) and then add/correct the organization for each PI.
+	 * 
+	 * @param omeMData
+	 * 		OME metadata to correct
+	 * @return
+	 * 		if any PI or organization names were changed
+	 * @throws IllegalArgumentException
+	 * 		if assigning a PI or organization name throws an exception
+	 */
+	public boolean fixNamesAndOrganizations(OmeMetadata omeMData) throws IllegalArgumentException {
+		boolean changed = false;
+		ArrayList<String> errNames = omeMData.getInvestigators();
+		ArrayList<String> errOrgs = omeMData.getOrganizations();
+		int numNames = errNames.size();
+
+		// TODO: match ? in error name correction template with any letter in err name
+		ArrayList<String> piNames = new ArrayList<String>(numNames);
+		ArrayList<String> piOrgs = new ArrayList<String>(numNames);
+		for (int k = 0; k < numNames; k++) {
+			String name = errNames.get(k);
+			String org = errOrgs.get(k);
+
+			ArrayList<String> replacement = nameFixMap.get(name);
+			if ( replacement != null ) {
+				// Name correction
+				changed = true;
+				piNames.addAll(replacement);
+				// Get the organization of the new name(s)
+				for ( String newName : replacement ) {
+					String newOrg = nameOrgMap.get(newName);
+					if ( newOrg == null ) {
+						newOrg = org;
+					}
+					piOrgs.add(newOrg);
+				}
+			}
+			else {
+				// No correction to the name; check the organization
+				piNames.add(name);
+				String newOrg = nameOrgMap.get(name);
+				if ( newOrg == null ) {
+					newOrg = org;
+				}
+				else if ( ! newOrg.equals(org) ) {
+					changed = true;
+				}
+				piOrgs.add(newOrg);
+			}
+		}
+
+		if ( changed ) {
+			numNames = piNames.size();
+			try {
+				omeMData.clearCompositeValueList(OmeMetadata.INVESTIGATOR_COMP_NAME);
+				for (int k = 0; k < numNames; k++) {
+					Properties props = new Properties();
+					props.setProperty(OmeMetadata.NAME_ELEMENT_NAME, piNames.get(k));
+					props.setProperty(OmeMetadata.ORGANIZATION_ELEMENT_NAME, piOrgs.get(k));
+					omeMData.storeCompositeValue(OmeMetadata.INVESTIGATOR_COMP_NAME, props, -1);
+				}
+			} catch ( Exception ex ) {
+				throw new IllegalArgumentException("problems updating names: " + ex.getMessage(), ex);
+			}
+		}
+		return changed;
+	}
+
+	/**
+	 * @param args
+	 * 		ExpocodesFile.txt  PINameCorrections.tsv  PINameOrganization.tsv
+	 */
+	public static void main(String[] args) {
+		if ( args.length != 3 ) {
+			System.err.println("Arguments:  ExpocodesFile  PINameCorrections.tsv  PINameOrganization.tsv");
+			System.err.println();
+			System.err.println("Corrects PI names in the OME.xml files for datasets whose expocodes are ");
+			System.err.println("given in ExpocodesFile.txt, one expocode per line.  PINameCorrections.tsv"); 
+			System.err.println("consists of mispelled 'name', tab, and correct name(s), where multiple ");
+			System.err.println("correct names are be separated by semicolons.  The PINameOrganization.tsv ");
+			System.err.println("file consists of (correct) PI name, tab, and organization name. "); 
+			System.err.println();
+			System.exit(1);
+		}
+		String expocodesFilename = args[0];
+		String piNameFixesFilename = args[1];
+		String piNameOrgFilename = args[2];
+
+		FixPINamesOrgs fixer = null;
+		try {
+			fixer = new FixPINamesOrgs(new File(piNameFixesFilename), new File(piNameOrgFilename));
+		} catch ( Exception ex ) {
+			System.err.println(ex.getMessage());
+			ex.printStackTrace();
+			System.exit(1);
+		}
+
+		// Get the expocodes of the datasets to update
+		TreeSet<String> allExpocodes = new TreeSet<String>();
+		try {
+			BufferedReader expoReader = new BufferedReader(new FileReader(expocodesFilename));
+			try {
+				String dataline = expoReader.readLine();
+				while ( dataline != null ) {
+
+					dataline = dataline.trim();
+					if ( ! ( dataline.isEmpty() || dataline.startsWith("#") ) ) {
+						String expocode = DashboardServerUtils.checkExpocode(dataline);
+						allExpocodes.add(expocode);
+					}
+
+					dataline = expoReader.readLine();
+				}
+			} finally {
+				expoReader.close();
+			}
+		} catch (Exception ex) {
+			System.err.println("Error getting expocodes from " + expocodesFilename + ": " + ex.getMessage());
+			ex.printStackTrace();
+			System.exit(1);
+		}
+
+		// Get the default dashboard configuration
+		DashboardConfigStore configStore = null;
+		try {
+			configStore = DashboardConfigStore.get(false);
+		} catch (Exception ex) {
+			System.err.println("Problems reading the default dashboard configuration file: " + ex.getMessage());
+			ex.printStackTrace();
+			System.exit(1);
+		}
+		try {
+			MetadataFileHandler mdataHandler = configStore.getMetadataFileHandler();
+
+			for ( String expocode : allExpocodes ) {
+				OmeMetadata omeMData = null;
+				File omeFile = mdataHandler.getMetadataFile(expocode, DashboardUtils.OME_FILENAME);
+				try {
+					Document omeDoc = (new SAXBuilder()).build(omeFile);
+					omeMData = new OmeMetadata(expocode);
+					omeMData.assignFromOmeXmlDoc(omeDoc);
+				} catch ( Exception ex ) {
+					System.err.println("Problems reading the OME file for " + expocode + ": " + ex.getMessage());
+					ex.printStackTrace();
+					System.exit(1);
+				}
+
+				boolean changed = false;
+				try {
+					changed = fixer.fixNamesAndOrganizations(omeMData);
+				} catch ( Exception ex ) {
+					System.err.println("Problems correcting the OME file for " + expocode + ": " + ex.getMessage());
+					ex.printStackTrace();
+					System.exit(1);	
+				}
+
+				if ( changed ) {
+					try {
+						Document dashDoc = omeMData.createOmeXmlDoc();
+						FileOutputStream out = new FileOutputStream(omeFile);
+						try {
+							(new XMLOutputter(Format.getPrettyFormat())).output(dashDoc, out);
+						} finally {
+							out.close();
+						}
+					} catch ( Exception ex ) {
+						throw new IllegalArgumentException("Problems writing the updated OME file: " + ex.getMessage());
+					}
+					System.err.println(expocode + ": updated");
+				}
+				else {
+					System.err.println(expocode + ": unchanged");
+				}
+			}
+
+		} finally {
+			DashboardConfigStore.shutdown();
+		}
+		System.exit(0);
+	}
+
+}

--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/programs/RegenerateDsgs.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/programs/RegenerateDsgs.java
@@ -195,6 +195,15 @@ public class RegenerateDsgs {
 				throw new IllegalArgumentException("Problems regenerating the full-data DSG files for " + 
 							upperExpo + ": " + ex.getMessage());
 			}
+
+			// Pause a bit to make sure the OS is done with the full-data DSG file.
+			// (Guessing at the cause of a very rare error message.)
+			try {
+				Thread.sleep(100);
+			} catch ( Exception ex ) {
+				; // Ignore
+			}
+
 			try {
 				// Regenerate the decimated-data DSG file 
 				dsgHandler.decimateCruise(upperExpo);

--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/programs/UpdateFromPIOme.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/programs/UpdateFromPIOme.java
@@ -61,6 +61,14 @@ public class UpdateFromPIOme {
 		Pattern punctPat = Pattern.compile("\\p{Punct}+");
 		Pattern spacePat = Pattern.compile("\\s+");
 
+		Pattern atmosPat1 = Pattern.compile("Atmosphere");
+		Pattern atmosPat2 = Pattern.compile("Atmospheric");
+		Pattern envPat1   = Pattern.compile("Environmental");
+		Pattern envPat2   = Pattern.compile("Environment");
+		Pattern instPat   = Pattern.compile("Institute");
+		Pattern labPat    = Pattern.compile("Laboratory");
+		Pattern univPat   = Pattern.compile("University");
+
 		// Get the default dashboard configuration
 		DashboardConfigStore configStore = null;
 		try {
@@ -161,18 +169,23 @@ public class UpdateFromPIOme {
 							continue;
 						lastFI += firsts[j].substring(0, 1) + ".";
 					}
+
+					// Clean up the organization name
 					String org = piOrgs.get(k);
 					if ( "Cooperative Institute for Research in Environmental Sciences/UCB".equals(org) ) {
 						org = "NOAA ESRL CIRES UCB";
 					}
 					else if ( "CSIRO".equals(org) ) {
-						org = "CSIRO Oceans and Atmosphere";
+						org = "CSIRO Oceans and Atmos";
 					}
 					else if ( "CSIR SOCO".equals(org) ) {
 						org = "CSIR SOCCO";
 					}
 					else if ( "Department of Atmospheric and Oceanic Sciences and Institute of Arctic and Alpine Research".equals(org) ) {
-						org = "IAAR University of Colorado";
+						org = "IAAR Univ of Colorado";
+					}
+					else if ( "Meteorological Research Institute".equals(org) ) {
+						org = "MRI Japan";
 					}
 					else if ( "National Institute for Environmental Studie".equals(org) ||
 							  "National Institute for Environmental Studies".equals(org)) {
@@ -185,7 +198,16 @@ public class UpdateFromPIOme {
 						// Replace all punctuation with spaces and remove all extra spaces
 						org = punctPat.matcher(org).replaceAll(" ");
 						org = spacePat.matcher(org).replaceAll(" ").trim();
+						// Abbreviate a few common long words
+						org = atmosPat1.matcher(org).replaceAll("Atmos");
+						org = atmosPat2.matcher(org).replaceAll("Atmos");
+						org = envPat1.matcher(org).replaceAll("Env");
+						org = envPat2.matcher(org).replaceAll("Env");
+						org = instPat.matcher(org).replaceAll("Inst");
+						org = labPat.matcher(org).replaceAll("Lab");
+						org = univPat.matcher(org).replaceAll("Univ");
 					}
+
 					System.err.println("Last name and first initial = '" + lastFI + "'");
 					System.err.println("Organization = '" + org + "'");
 					Properties props = new Properties();

--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/programs/UpdateFromPIOme.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/programs/UpdateFromPIOme.java
@@ -1,0 +1,149 @@
+/**
+ * 
+ */
+package gov.noaa.pmel.dashboard.programs;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Properties;
+
+import org.jdom2.Document;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+
+import gov.noaa.pmel.dashboard.handlers.MetadataFileHandler;
+import gov.noaa.pmel.dashboard.server.DashboardConfigStore;
+import gov.noaa.pmel.dashboard.server.DashboardServerUtils;
+import gov.noaa.pmel.dashboard.shared.DashboardUtils;
+import uk.ac.uea.socat.omemetadata.OmeMetadata;
+
+/**
+ * Updates dashboard's OME.xml from values given in the PI-provided OME.xml
+ * 
+ * @author Karl Smith
+ */
+public class UpdateFromPIOme {
+
+	/**
+	 * @param args
+	 * 		expocode -	expoocode of the dataset to update the OME.xml from the PI_OME.xml
+	 */
+	public static void main(String[] args) {
+		String expocode;
+		try {
+			expocode = DashboardServerUtils.checkExpocode(args[0]);
+		} catch ( Exception ex ) {
+			expocode = null;
+		}
+		if ( (args.length != 1) || (expocode == null) ) {
+			if ( args.length == 1 ) {
+				System.err.println("");
+				System.err.println("expocode not valid: " + args[0]);
+			}
+			System.err.println("");
+			System.err.println("Arguments: expocode");
+			System.err.println("");
+			System.err.println("For the dataset with the given expocode, update some basic information ");
+			System.err.println("in the dashboard OME.xml from the values in the PI-provided OME.xml document. ");
+			System.err.println("PI names in the PI-provided OME.xml will be modified to 'lastname, firstinitial' ");
+			System.err.println("as best possible.  Other values are copied as given: organization for each PI, ");
+			System.err.println("platform name, and platform type. ");
+			System.err.println("");
+			System.exit(1);
+		}
+
+		// Get the default dashboard configuration
+		DashboardConfigStore configStore = null;
+		try {
+			configStore = DashboardConfigStore.get(false);
+		} catch (Exception ex) {
+			System.err.println("Problems reading the default dashboard configuration file: " + ex.getMessage());
+			ex.printStackTrace();
+			System.exit(1);
+		}
+		try {
+
+			MetadataFileHandler mdataHandler = configStore.getMetadataFileHandler();
+			String platformName = null;
+			String platformType = null;
+			ArrayList<String> piNames = null;
+			ArrayList<String> piOrgs = null;
+			try {
+				File piOmeFile = mdataHandler.getMetadataFile(expocode, DashboardUtils.PI_OME_FILENAME);
+				Document omeDoc = (new SAXBuilder()).build(piOmeFile);
+				OmeMetadata piOme = new OmeMetadata(expocode);
+				piOme.assignFromOmeXmlDoc(omeDoc);
+				platformName = piOme.getVesselName();
+				platformType = piOme.getValue(OmeMetadata.PLATFORM_TYPE_STRING);
+				piNames = piOme.getInvestigators();
+				piOrgs = piOme.getOrganizations();
+			} catch ( Exception ex ) {
+				System.err.println("Problems reading the PI-provided OME file: " + ex.getMessage());
+				ex.printStackTrace();
+				System.exit(1);
+			}
+
+			File dashOmeFile = mdataHandler.getMetadataFile(expocode, DashboardUtils.OME_FILENAME);
+			OmeMetadata dashOme = new OmeMetadata(expocode);
+			try {
+				Document omeDoc = (new SAXBuilder()).build(dashOmeFile);
+				dashOme.assignFromOmeXmlDoc(omeDoc);
+				dashOme.replaceValue(OmeMetadata.VESSEL_NAME_STRING, platformName, -1);
+				dashOme.replaceValue(OmeMetadata.PLATFORM_TYPE_STRING, platformType, -1);
+				dashOme.clearCompositeValueList(OmeMetadata.INVESTIGATOR_COMP_NAME);
+				for (int k = 0; k < piNames.size(); k++) {
+					String last = null;
+					String[] firsts = null;
+					int numFirsts = 0;
+					String[] pieces = piNames.get(k).split(",");
+					if ( pieces.length > 1 ) {
+						last = pieces[0];
+						firsts = pieces[1].split("\\s+");
+						numFirsts = firsts.length;
+					}
+					else {
+						firsts = pieces[0].split("\\s+");
+						numFirsts = pieces.length - 1;
+						last = pieces[numFirsts];
+					}
+					String lastFI = last + ", ";
+					for (int j = 0; j < numFirsts; j++) {
+						String name = firsts[j];
+						if ( "Dr".equalsIgnoreCase(name) || "Dr.".equalsIgnoreCase(name) ||
+							 "Pf".equalsIgnoreCase(name) || "Pf.".equalsIgnoreCase(name) )
+							continue;
+						lastFI += firsts[j].substring(0, 1) + ".";
+					}
+					Properties props = new Properties();
+					props.setProperty(OmeMetadata.NAME_ELEMENT_NAME, lastFI);
+					props.setProperty(OmeMetadata.ORGANIZATION_ELEMENT_NAME, piOrgs.get(k));
+					dashOme.storeCompositeValue(OmeMetadata.INVESTIGATOR_COMP_NAME, props, -1);
+				}
+			} catch ( Exception ex ) {
+				System.err.println("Problems reading (or updating) the dashboard OME file: " + ex.getMessage());
+				ex.printStackTrace();
+				System.exit(1);
+			}
+
+			try {
+				Document dashDoc = dashOme.createOmeXmlDoc();
+				FileOutputStream out = new FileOutputStream(dashOmeFile);
+				try {
+					(new XMLOutputter(Format.getPrettyFormat())).output(dashDoc, out);
+				} finally {
+					out.close();
+				}
+			} catch (IOException ex) {
+				throw new IllegalArgumentException("Problems writing the updated dashboard OME: " + ex.getMessage());
+			}
+
+		} finally {
+			DashboardConfigStore.shutdown();
+		}
+		System.exit(0);
+	}
+
+}

--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/server/DashboardOmeMetadata.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/server/DashboardOmeMetadata.java
@@ -252,14 +252,22 @@ public class DashboardOmeMetadata extends DashboardMetadata {
 		HashSet<String> usedOrganizations = new HashSet<String>();
 		StringBuffer orgGroup = new StringBuffer();
 		for ( String org : omeMData.getOrganizations() ) {
-			if ( (null != org) && usedOrganizations.add(org) ) {
+			if ( org == null )
+				continue;
+			org = org.trim();
+			if ( org.isEmpty() )
+				continue;
+			if ( usedOrganizations.add(org) ) {
 				if ( orgGroup.length() > 0 )
 					orgGroup.append(NAMES_SEPARATOR);
 				// Anglicize organizations names for NetCDF/LAS
 				orgGroup.append(anglicizeName(org));
 			}
 		}
-		scMData.setOrganizationName(orgGroup.toString());
+		String allOrgs = orgGroup.toString().trim();
+		if ( allOrgs.isEmpty() )
+			allOrgs = "(not assigned)";
+		scMData.setOrganizationName(allOrgs);
 
 		return scMData;
 	}

--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/server/DashboardOmeMetadata.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/server/DashboardOmeMetadata.java
@@ -706,6 +706,8 @@ public class DashboardOmeMetadata extends DashboardMetadata {
 		PI_NAME_CORRECTIONS.put("Jutterstroem, S.", "Jutterstr" + oUmlaut + "m, S.");
 		PI_NAME_CORRECTIONS.put("Koertzinger, A.", "K" + oUmlaut + "rtzinger, A.");
 		PI_NAME_CORRECTIONS.put("Lefevre, N.", "Lef" + eGrave + "vre, N.");
+		PI_NAME_CORRECTIONS.put("Olafsdottir, S.", OAcute + "lafsd" + oAcute + "ttir, S.");
+		PI_NAME_CORRECTIONS.put("Olafsson, J.", OAcute + "lafsson, J.");
 		PI_NAME_CORRECTIONS.put("Perez, F.F.", "P" + eAcute + "rez, F.F.");
 		PI_NAME_CORRECTIONS.put("Rios, A.F.", "R" + iAcute + "os, A.F.");
 		PI_NAME_CORRECTIONS.put("Treguer, P.", "Tr" + eAcute + "guer, P.");

--- a/UploadDashboard/src/gov/noaa/pmel/dashboard/server/DashboardOmeMetadata.java
+++ b/UploadDashboard/src/gov/noaa/pmel/dashboard/server/DashboardOmeMetadata.java
@@ -266,7 +266,7 @@ public class DashboardOmeMetadata extends DashboardMetadata {
 		}
 		String allOrgs = orgGroup.toString().trim();
 		if ( allOrgs.isEmpty() )
-			allOrgs = "(not assigned)";
+			allOrgs = "unassigned";
 		scMData.setOrganizationName(allOrgs);
 
 		return scMData;


### PR DESCRIPTION
UpdateFromPIOme app added first - gets PI names and organizations from the PI-provided OME.xml.  Then FixPINamesOrgs added which uses TSV files of incorrect PI name(s) to correct PI name(s), and organization for the (correct) PI name.  

Also trivial change adding OCADS to archival request email subject and message.