### PR TITLE
Bug fixes to get the dashboard working properly again

### DIFF
--- a/UploadDashboard/SampleConfigFiles/DatabaseConfig.properties
+++ b/UploadDashboard/SampleConfigFiles/DatabaseConfig.properties
@@ -1,5 +1,6 @@
 sqldriver=com.mysql.jdbc.Driver
 databaseurl=jdbc\:mysql\://localhost\:3306/SOCATFlags?autoReconnect\=true&useSSL\=False
+# databaseurl=jdbc\:mysql\://localhost\:3306/SOCATFlags?autoReconnect\=true&useSSL\=False&useUnicode\=true&characterEncoding\=UTF-8
 selectuser=publicuser
 selectpass=publicuserpassword
 updateuser=scientist

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/actions/DatasetChecker.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/actions/DatasetChecker.java
@@ -164,8 +164,12 @@ public class DatasetChecker {
         }
 
         if ( metadata != null ) {
-            // TODO:
-            throw new IllegalArgumentException("updating metdata from data values not yet implemented");
+            for (RowColumn rowCol : userErrs) {
+                errRows.add(rowCol.getRow());
+            }
+            Double[] sampleLongitudes = stdUserData.getSampleLongitudes();
+            Double[] sampleLatitudes = stdUserData.getSampleLatitudes();
+            metadata.assignLonLatTimeLimits(sampleLongitudes, sampleLatitudes, sampleTimes, errRows);
         }
 
         return stdUserData;

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/datatype/SocatTypes.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/datatype/SocatTypes.java
@@ -40,12 +40,12 @@ public class SocatTypes {
 
     public static final DoubleDashDataType TEQU = new DoubleDashDataType("Temperature_equi",
             610.0, "T_equ", "equilibrator chamber temperature", false,
-            TEMPERATURE_UNITS, null, TEMPERATURE_CATEGORY, "degrees_C",
+            TEMPERATURE_UNITS, null, TEMPERATURE_CATEGORY, "degrees C",
             "-10.0", "-5.0", "40.0", "50.0", DashboardServerUtils.USER_FILE_DATA_ROLES);
 
     public static final DoubleDashDataType SST = new DoubleDashDataType("temp",
             611.0, "SST", "sea surface temperature", false,
-            TEMPERATURE_UNITS, "sea_surface_temperature", TEMPERATURE_CATEGORY, "degrees_C",
+            TEMPERATURE_UNITS, "sea_surface_temperature", TEMPERATURE_CATEGORY, "degrees C",
             "-10.0", "-5.0", "40.0", "50.0", DashboardServerUtils.USER_FILE_DATA_ROLES);
 
     public static final DoubleDashDataType PEQU = new DoubleDashDataType("Pressure_equi",
@@ -153,7 +153,7 @@ public class SocatTypes {
 
     public static final DoubleDashDataType DELTA_TEMP = new DoubleDashDataType("delta_temp",
             703.0, "delta_temp", "Equilibrator Temp - SST", false,
-            TEMPERATURE_UNITS, null, TEMPERATURE_CATEGORY, "degrees_C",
+            TEMPERATURE_UNITS, null, TEMPERATURE_CATEGORY, "degrees C",
             null, null, null, null, DashboardServerUtils.FILE_DATA_ONLY_ROLES);
 
     // The limits on CALC_SPEED (in knots) are used to check time/location values

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/handlers/DataFileHandler.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/handlers/DataFileHandler.java
@@ -342,9 +342,9 @@ public class DataFileHandler extends VersionedFileHandler {
 
                 // Still reading metadata?
                 if ( columnNames == null ) {
-                    // Put this line of metadata back together using spacer
-                    // but since metadata, no need for blank columns with spacers (if any)
-                    String metaline = rebuildDataline(record, spacer, true);
+                    // Put this line of metadata back together with space-characters as spacers,
+                    // without double-quotes, and without blank columns
+                    String metaline = rebuildDataline(record, ' ', true);
 
                     // Examine this metadata line for the expocode
                     if ( (expocode == null) && !metaline.isEmpty() ) {
@@ -1427,7 +1427,8 @@ public class DataFileHandler extends VersionedFileHandler {
      * @param record
      *         record to use
      * @param spacer
-     *         spacer to use
+     *         spacer to use.  If a singe-space character, the columns are not double-quoted;
+     *         otherwise column entries are double-quoted if they contain this character
      * @param trimEmpty
      *         remove empty entries (and spacers for those entries)
      *
@@ -1446,7 +1447,7 @@ public class DataFileHandler extends VersionedFileHandler {
                 builder.append(spacer);
             }
             if ( !val.isEmpty() ) {
-                if ( val.contains(Character.toString(spacer)) ) {
+                if ( (spacer != ' ') && val.contains(Character.toString(spacer)) ) {
                     builder.append('"');
                     builder.append(val);
                     builder.append('"');

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/handlers/PreviewPlotsHandler.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/handlers/PreviewPlotsHandler.java
@@ -143,9 +143,7 @@ public class PreviewPlotsHandler {
         dsgMData.setDatasetId(stdId);
         dsgMData.setVersion(dataset.getVersion());
 
-        // TODO: update DsgMetadata with metadata derived from data
-        // Although probably not important for the preview plots.
-        StdUserDataArray stdUserData = dataChecker.standardizeDataset(dataset, null);
+        StdUserDataArray stdUserData = dataChecker.standardizeDataset(dataset, dsgMData);
         if ( DashboardUtils.CHECK_STATUS_UNACCEPTABLE.equals(dataset.getDataCheckStatus()) )
             throw new IllegalArgumentException(stdId + ": unacceptable; check data check error messages " +
                     "(missing lon/lat/depth/time or uninterpretable values)");

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/qc/RowColumn.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/qc/RowColumn.java
@@ -8,8 +8,8 @@ import gov.noaa.pmel.dashboard.shared.DashboardUtils;
  */
 public class RowColumn implements Comparable<RowColumn> {
 
-    Integer row;
-    Integer column;
+    private Integer row;
+    private Integer column;
 
     /**
      * @param rowIndex
@@ -26,6 +26,20 @@ public class RowColumn implements Comparable<RowColumn> {
             column = DashboardUtils.INT_MISSING_VALUE;
         else
             column = columnIndex;
+    }
+
+    /**
+     * @return the row index
+     */
+    public Integer getRow() {
+        return row;
+    }
+
+    /**
+     * @return the column index
+     */
+    public Integer getColumn() {
+        return column;
     }
 
     @Override

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/server/DashboardServerUtils.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/server/DashboardServerUtils.java
@@ -266,7 +266,7 @@ public class DashboardServerUtils {
      * User-provided name for the dataset
      */
     public static final StringDashDataType DATASET_NAME = new StringDashDataType("dataset_name",
-            100.0, "cruise/dataset name", "investigator's name for this dataset", false,
+            100.0, "cruise/dataset name", "name for this dataset used by investigator", false,
             DashboardUtils.NO_UNITS, "dataset_name", IDENTIFIER_CATEGORY, null,
             null, null, null, null, USER_FILE_METADATA_ROLES);
 
@@ -286,7 +286,7 @@ public class DashboardServerUtils {
             null, null, null, null, USER_FILE_METADATA_ROLES);
 
     public static final StringDashDataType ORGANIZATION_NAME = new StringDashDataType("organization",
-            104.0, "PI organizations", "organization for each PI", false,
+            104.0, "organizations", "organizations", false,
             DashboardUtils.NO_UNITS, "organization", IDENTIFIER_CATEGORY, null,
             null, null, null, null, USER_FILE_METADATA_ROLES);
 
@@ -336,7 +336,7 @@ public class DashboardServerUtils {
             null, null, null, null, FILE_METADATA_ONLY_ROLES);
 
     public static final StringDashDataType VERSION = new StringDashDataType("socat_version",
-            123.0, "socat_version", "SOCAT version", false,
+            123.0, "socat_version", "SOCAT version with status", false,
             DashboardUtils.NO_UNITS, null, IDENTIFIER_CATEGORY, null,
             null, null, null, null, FILE_METADATA_ONLY_ROLES);
 

--- a/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/actualdata/DataFileHandlerTest.java
+++ b/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/actualdata/DataFileHandlerTest.java
@@ -92,7 +92,7 @@ public class DataFileHandlerTest {
     private static final ArrayList<String> META_PREAMBLE = new ArrayList<String>(Arrays.asList(
             "# Expocode: 00KS20120419",
             "#Ship: Atlantis",
-            "\"PI: Wanninkhof, R.\"",
+            "PI: Wanninkhof, R.",
             ""));
 
     private static final ArrayList<String> HEADERS = new ArrayList<String>(Arrays.asList(

--- a/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/dsg/DsgMetadataTest.java
+++ b/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/dsg/DsgMetadataTest.java
@@ -10,7 +10,10 @@ import gov.noaa.pmel.dashboard.server.DashboardServerUtils;
 import gov.noaa.pmel.dashboard.shared.DashboardUtils;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.TreeMap;
 
 import static org.junit.Assert.assertEquals;
@@ -467,6 +470,63 @@ public class DsgMetadataTest {
         assertEquals(64, mdata.getMaxStringLength());
         mdata.setDatasetName("AShortName.tsv");
         assertEquals(32, mdata.getMaxStringLength());
+    }
+
+    /**
+     * Test method for {@link DsgMetadata#assignLonLatTimeLimits(Double[], Double[], Double[], Set)}
+     */
+    @Test
+    public void testAssignLonLatTimeLimits() {
+        HashSet<Integer> errRowIdxs = new HashSet<Integer>(Arrays.asList(0, 3, 14));
+        Double[] sampleLons = new Double[] {
+                145.0, 165.0, 155.0, -999.0, -180.0,
+                160.0, -175.0, 175.0, -170.0, -165.0,
+                -175.0, -180.0, 180.0, 175.0, -999.0
+        };
+        Double[] expectedWestEastLon = new Double[] { 155.0, -165.0 };
+        Double[] sampleLats = new Double[] {
+                20.0, 10.0, 5.0, -999.0, 7.5,
+                10.0, 12.5, 15.0, 12.5, 10.0,
+                5.0, 0.0, -5.0, -10.0, -999.0
+        };
+        Double[] expectedSouthNorthLat = new Double[] { -10.0, 15.0 };
+        Double[] sampleTimes = new Double[] {
+                -99999.0, 105060.0, 105120.0, -99999.0, 105240.0,
+                105300.0, 105360.0, 105420.0, 105480.0, 105540.0,
+                105600.0, 105660.0, 105720.0, 105780.0, 105840.0
+        };
+        Double[] expectedBeginEndTime = new Double[] { 105060.0, 105780.0 };
+
+        KnownDataTypes knownTypes = new KnownDataTypes().addStandardTypesForMetadataFiles();
+        DsgMetadata mdata = new DsgMetadata(knownTypes);
+        mdata.assignLonLatTimeLimits(sampleLons, sampleLats, sampleTimes, errRowIdxs);
+        assertEquals(expectedWestEastLon[0], mdata.getWestmostLongitude());
+        assertEquals(expectedWestEastLon[1], mdata.getEastmostLongitude());
+        assertEquals(expectedSouthNorthLat[0], mdata.getSouthmostLatitude());
+        assertEquals(expectedSouthNorthLat[1], mdata.getNorthmostLatitude());
+        assertEquals(expectedBeginEndTime[0], mdata.getBeginTime());
+        assertEquals(expectedBeginEndTime[1], mdata.getEndTime());
+
+        sampleLons = new Double[] {
+                -999.0, 25.0, 65.0, -999.0, 105.0,
+                145.0, -175.0, -135.0, -95.0, -55.0,
+                -15.0, 20.0, 50.0, 65.0, -999.0
+        };
+        expectedWestEastLon = new Double[] { -180.0, 180.0 };
+        sampleLats = new Double[] {
+                -999.0, 89.0, 88.0, -999.0, 89.5,
+                89.0, 88.5, 89.0, 89.5, 89.0,
+                89.5, 89.0, 88.5, 89.0, -999.0
+        };
+        expectedSouthNorthLat = new Double[] { 88.0, 89.5 };
+
+        mdata.assignLonLatTimeLimits(sampleLons, sampleLats, sampleTimes, errRowIdxs);
+        assertEquals(expectedWestEastLon[0], mdata.getWestmostLongitude());
+        assertEquals(expectedWestEastLon[1], mdata.getEastmostLongitude());
+        assertEquals(expectedSouthNorthLat[0], mdata.getSouthmostLatitude());
+        assertEquals(expectedSouthNorthLat[1], mdata.getNorthmostLatitude());
+        assertEquals(expectedBeginEndTime[0], mdata.getBeginTime());
+        assertEquals(expectedBeginEndTime[1], mdata.getEndTime());
     }
 
     /**


### PR DESCRIPTION
Change unit of "degrees_C" (the CF standard) in the NetCDF files to "degrees C" to be compatible with  preciously generated NetCDF files (so they will be accepted by ERDDAP).
Add the N or U QC flags to the NetCDF files when submitting new and updated datasets.
Add data-derived metadata (lon/lat/time limits) to the NetCDF files.
For metadata lines (preamble), put them back together using a space for the "spacer" and do not add double quotes (in essence, concatenating all column values with spaces and trimming the resulting line).