### PR TITLE
Include comments in automated metadata QC

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -2,41 +2,47 @@
   <code_scheme name="Project" version="173">
     <JavaCodeStyleSettings>
       <option name="SPACE_AFTER_CLOSING_ANGLE_BRACKET_IN_TYPE_ARGUMENT" value="true" />
-      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="50" />
-      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="50" />
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="500" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="300" />
+      <option name="JD_ADD_BLANK_AFTER_PARM_COMMENTS" value="true" />
+      <option name="JD_ADD_BLANK_AFTER_RETURN" value="true" />
       <option name="JD_PARAM_DESCRIPTION_ON_NEW_LINE" value="true" />
+      <option name="JD_INDENT_ON_CONTINUATION" value="true" />
     </JavaCodeStyleSettings>
     <codeStyleSettings language="JAVA">
-      <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
-      <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
       <option name="ELSE_ON_NEW_LINE" value="true" />
       <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
-      <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
-      <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
       <option name="ALIGN_MULTILINE_FOR" value="false" />
-      <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
       <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
       <option name="SPACE_AFTER_COMMA_IN_TYPE_ARGUMENTS" value="false" />
-      <option name="SPACE_WITHIN_PARENTHESES" value="true" />
       <option name="SPACE_WITHIN_IF_PARENTHESES" value="true" />
       <option name="SPACE_WITHIN_WHILE_PARENTHESES" value="true" />
+      <option name="SPACE_WITHIN_TRY_PARENTHESES" value="true" />
+      <option name="SPACE_WITHIN_CATCH_PARENTHESES" value="true" />
       <option name="SPACE_WITHIN_SWITCH_PARENTHESES" value="true" />
+      <option name="SPACE_WITHIN_SYNCHRONIZED_PARENTHESES" value="true" />
       <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
       <option name="SPACE_WITHIN_EMPTY_ARRAY_INITIALIZER_BRACES" value="true" />
-      <option name="SPACE_BEFORE_SYNCHRONIZED_PARENTHESES" value="false" />
       <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
       <option name="CALL_PARAMETERS_WRAP" value="1" />
-      <option name="PREFER_PARAMETERS_WRAP" value="true" />
       <option name="METHOD_PARAMETERS_WRAP" value="1" />
+      <option name="RESOURCE_LIST_WRAP" value="1" />
       <option name="EXTENDS_LIST_WRAP" value="1" />
       <option name="THROWS_LIST_WRAP" value="1" />
       <option name="EXTENDS_KEYWORD_WRAP" value="1" />
       <option name="THROWS_KEYWORD_WRAP" value="1" />
       <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="TERNARY_OPERATION_WRAP" value="1" />
       <option name="FOR_STATEMENT_WRAP" value="1" />
+      <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+      <option name="ASSIGNMENT_WRAP" value="1" />
+      <option name="ASSERT_STATEMENT_WRAP" value="1" />
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
+      <option name="ENUM_CONSTANTS_WRAP" value="5" />
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -24,7 +24,7 @@
       </entry>
     </default-configurations>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="openjdk-13" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/target" />
   </component>
 </project>

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/actions/DatasetSubmitter.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/actions/DatasetSubmitter.java
@@ -216,9 +216,9 @@ public class DatasetSubmitter {
 
                 // Now mark the dataset as submitted in this version
                 if ( dataset.getSubmitStatus().isPrivate() )
-                    dataset.setSubmitStatus(new DatasetQCStatus(DatasetQCStatus.Status.NEW_AWAITING_QC));
+                    dataset.setSubmitStatus(new DatasetQCStatus(DatasetQCStatus.Status.NEW_AWAITING_QC, ""));
                 else
-                    dataset.setSubmitStatus(new DatasetQCStatus(DatasetQCStatus.Status.UPDATED_AWAITING_QC));
+                    dataset.setSubmitStatus(new DatasetQCStatus(DatasetQCStatus.Status.UPDATED_AWAITING_QC, ""));
                 dataset.setVersion(version);
 
                 // Set up to save changes to version control
@@ -334,12 +334,12 @@ public class DatasetSubmitter {
         DatasetQCStatus flag;
         String comment;
         if ( dataset.getSubmitStatus().isPrivate() ) {
-            flag = new DatasetQCStatus(DatasetQCStatus.Status.NEW_AWAITING_QC);
             comment = "Initial QC flag for new dataset";
+            flag = new DatasetQCStatus(DatasetQCStatus.Status.NEW_AWAITING_QC, comment);
         }
         else {
-            flag = new DatasetQCStatus(DatasetQCStatus.Status.UPDATED_AWAITING_QC);
             comment = "Initial QC flag for updated dataset";
+            flag = new DatasetQCStatus(DatasetQCStatus.Status.UPDATED_AWAITING_QC, comment);
         }
         // First add a global flag, then flag for each region
         ArrayList<String> regions = new ArrayList<String>(allRegionIds.length() + 1);

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/handlers/DatabaseRequestHandler.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/handlers/DatabaseRequestHandler.java
@@ -469,7 +469,7 @@ public class DatabaseRequestHandler {
         long globalTime;
         if ( globalEvent == null ) {
             // Some v1 cruises do not have global flags
-            globalFlag = new DatasetQCStatus(DatasetQCStatus.Status.NEW_AWAITING_QC);
+            globalFlag = new DatasetQCStatus(DatasetQCStatus.Status.NEW_AWAITING_QC, "");
             globalTime = lastUpdateTime;
         }
         else {
@@ -505,7 +505,7 @@ public class DatabaseRequestHandler {
             }
             else if ( !latestFlag.getActual().equals(flag.getActual()) ) {
                 // conflicts only occur with mismatches in the actual flag
-                return new DatasetQCStatus(DatasetQCStatus.Status.CONFLICTED);
+                return new DatasetQCStatus(DatasetQCStatus.Status.CONFLICTED, "");
             }
         }
         if ( latestFlag == null ) {

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/metadata/CdiacOmeMetadata.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/metadata/CdiacOmeMetadata.java
@@ -417,7 +417,7 @@ public class CdiacOmeMetadata implements OmeMetadataInterface {
     }
 
     @Override
-    public DatasetQCStatus.Status suggestedDatasetStatus(DashboardDataset dataset) throws IllegalArgumentException {
+    public DatasetQCStatus suggestedDatasetStatus(DashboardDataset dataset) throws IllegalArgumentException {
         SDIMetadata sdiMData;
         try {
             Document omeDoc = mdata.createOmeXmlDoc();

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/metadata/DashboardOmeMetadata.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/metadata/DashboardOmeMetadata.java
@@ -27,7 +27,7 @@ import java.util.TimeZone;
  */
 public class DashboardOmeMetadata extends DashboardMetadata {
 
-    private static final long serialVersionUID = 6474058539002011239L;
+    private static final long serialVersionUID = 353927270709646644L;
 
     /**
      * String separating each PI listed in scienceGroup, each organization listed in organizations, and each additional
@@ -404,18 +404,18 @@ public class DashboardOmeMetadata extends DashboardMetadata {
 
     /**
      * Using the contents of this OME document, recommend a QC flag/status for this dataset.
+     * The returned dataset QC will have the autoSuggested flag assigned as well as
+     * a single comment documenting the reason for this suggested Status.
      *
      * @param dataset
      *         information about the dataset associated with this OME document
      *
-     * @return the automation-suggested dataset QC flag, an appropriate acceptable status
-     *         ({@link DatasetQCStatus.Status#isAcceptable(DatasetQCStatus.Status)} returns true).
+     * @return the automation-suggested dataset QC
      *
      * @throws IllegalArgumentException
-     *         if there are problems with the given Metadata, or
-     *         if the metadata indicates the dataset in unacceptable
+     *         if there are problems with the given Metadata
      */
-    public DatasetQCStatus.Status suggestedDatasetStatus(DashboardDataset dataset) throws IllegalArgumentException {
+    public DatasetQCStatus suggestedDatasetStatus(DashboardDataset dataset) throws IllegalArgumentException {
         return omeMData.suggestedDatasetStatus(dataset);
     }
 

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/metadata/OmeMetadataInterface.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/metadata/OmeMetadataInterface.java
@@ -205,17 +205,18 @@ public interface OmeMetadataInterface {
 
     /**
      * Using the contents of this OME document, recommend a QC flag/status for this dataset.
+     * The returned dataset QC will have the autoSuggested flag assigned as well as
+     * a single comment documenting the reason for this suggested Status.
      *
      * @param dataset
      *         information about the dataset associated with this OME document
      *
-     * @return the automation-suggested dataset QC flag, an appropriate acceptable status
-     *         ({@link DatasetQCStatus.Status#isAcceptable(DatasetQCStatus.Status)} returns true).
+     * @return the automation-suggested dataset QC
      *
      * @throws IllegalArgumentException
-     *         if there are problems with the given Metadata, or
-     *         if the metadata indicates the dataset in unacceptable
+     *         if there are problems with the given Metadata
      */
-    DatasetQCStatus.Status suggestedDatasetStatus(DashboardDataset dataset) throws IllegalArgumentException;
+
+    DatasetQCStatus suggestedDatasetStatus(DashboardDataset dataset) throws IllegalArgumentException;
 
 }

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/metadata/OmeUtils.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/metadata/OmeUtils.java
@@ -177,24 +177,21 @@ public class OmeUtils {
             .compile("[\\p{Space}\\p{Punct}]*(.*?)[\\p{Space}\\p{Punct}]*");
 
     /**
-     * Using the contents of the given SDIMetadata, recommend a QC flag/status for this dataset.
-     * This does NOT check actual data values that affect the dataset QC flag (e.g., the range
-     * of fCO2 values to compare against calibration gas concentrations, or amount of warming
-     * between in-situ temperatures and equilibrator temperatures).
+     * Using the contents of the given SDIMetadata, recommend a QC status/flag for this dataset.
+     * The returned dataset QC will have the autoSuggested flag assigned as well as
+     * a single comment documenting the reason for this suggested Status.
      *
      * @param sdiMData
      *         metadata to examine
      * @param dataset
      *         dataset associated with this metadata
      *
-     * @return the automation-suggested dataset QC flag, an appropriate acceptable status
-     *         ({@link DatasetQCStatus.Status#isAcceptable(DatasetQCStatus.Status)} returns true).
+     * @return the automation-suggested dataset QC
      *
      * @throws IllegalArgumentException
-     *         if there are problems with the given Metadata, or
-     *         if the metadata indicates the dataset in unacceptable
+     *         if there are problems with the given Metadata
      */
-    public static DatasetQCStatus.Status suggestDatasetQCFlag(SDIMetadata sdiMData,
+    public static DatasetQCStatus suggestDatasetQCFlag(SDIMetadata sdiMData,
             DashboardDataset dataset) throws IllegalArgumentException {
         HashMap<String,GasSensor> co2SensorsMap = new HashMap<String,GasSensor>();
         for (Instrument instrument : sdiMData.getInstruments()) {
@@ -258,19 +255,34 @@ public class OmeUtils {
                 co2Accuracy = accuracy.getNumericValue();
         }
         DatasetQCStatus.Status autoSuggest;
-        if ( co2Accuracy <= 2.0 )
+        String comment;
+        if ( co2Accuracy <= 2.0 ) {
+            comment = "Accuracy of aqueous CO2 less than 2 uatm.  ";
             autoSuggest = DatasetQCStatus.Status.ACCEPTED_B;
-        else if ( co2Accuracy <= 5.0 )
+        }
+        else if ( co2Accuracy <= 5.0 ) {
+            comment = "Accuracy of aqueous CO2 less than 5 uatm.  ";
             autoSuggest = DatasetQCStatus.Status.ACCEPTED_C;
-        else
-            throw new IllegalArgumentException("Unacceptably large accuracy for the aqueous CO2 measurements");
-        // Alternative sensors with CO2 accuracy within 10.0 could be ACCEPTED_E.  However, they need a clear
-        // and detailed description of the calibration, so an automation-suggested flag is not possible.
+        }
+        else {
+            // Alternative sensors with CO2 accuracy within 10.0 could be ACCEPTED_E.  However, they need a clear
+            // and detailed description of the calibration, so an automation-suggested flag is not possible.
+            comment = "Accuracy of aqueous CO2 coould not be determined or was greater than 5 uatm; " +
+                    "alternate sensors (flag E) were not considered.";
+            DatasetQCStatus status = new DatasetQCStatus(DatasetQCStatus.Status.PRIVATE, comment);
+            status.setAutoSuggested(DatasetQCStatus.Status.SUSPENDED);
+            return status;
+        }
 
         // Rough judgement on whether metadata is complete
         boolean acceptable = true;
         HashSet<String> invalids = sdiMData.invalidFieldNames();
         if ( invalids.size() > 0 ) {
+            comment += "Metadata incomplete: ";
+            for (String expl : invalids) {
+                comment += expl + "; ";
+            }
+            comment += ".  ";
             acceptable = false;
         }
         else {
@@ -285,13 +297,15 @@ public class OmeUtils {
                     continue;
                 String name = colNames.get(k);
                 if ( !varColNames.contains(name) ) {
+                    comment += "Metadata incomplete: data column '" + name + "' is not described in the metadata.  ";
                     acceptable = false;
                     break;
                 }
             }
         }
-        if ( !acceptable )
+        if ( !acceptable ) {
             autoSuggest = DatasetQCStatus.Status.ACCEPTED_D;
+        }
 
         // Alternative sensors with CO2 accuracy within 5.0 are not subject to the temperature
         // and pressure restrictions.  However, they need a clear and detailed description of
@@ -306,10 +320,21 @@ public class OmeUtils {
             if ( tempAccuracy > accuracy.getNumericValue() )
                 tempAccuracy = accuracy.getNumericValue();
         }
-        if ( tempAccuracy > 0.2 )
-            throw new IllegalArgumentException("Unacceptably large accuracy in temperature measurements");
-        if ( autoSuggest.equals(DatasetQCStatus.Status.ACCEPTED_B) && (tempAccuracy > 0.05) )
-            autoSuggest = DatasetQCStatus.Status.ACCEPTED_C;
+        if ( tempAccuracy <= 0.05 ) {
+            comment += "Accuracy of temperature measurements 0.05 °C or less.  ";
+        }
+        else if ( tempAccuracy <= 0.2 ) {
+            comment += "Accuracy of temperature measurements between 0.05 and 0.2 °C.  ";
+            if ( autoSuggest.equals(DatasetQCStatus.Status.ACCEPTED_B) )
+                autoSuggest = DatasetQCStatus.Status.ACCEPTED_C;
+        }
+        else {
+            comment += "Accuracy of temperature measurements could not be determined or exceeds 0.2 °C; " +
+                    "alternatve sensors (flag E) were not considered.";
+            DatasetQCStatus status = new DatasetQCStatus(DatasetQCStatus.Status.PRIVATE, comment);
+            status.setAutoSuggested(DatasetQCStatus.Status.SUSPENDED);
+            return status;
+        }
 
         // Accuracy of air pressure within 5.0 hPa (2.0 hPa for ACCEPTED_B)
         // TODO: If equilibrator pressure is the sum of an external pressure sensor and
@@ -321,10 +346,27 @@ public class OmeUtils {
             if ( pressAccuracy > accuracy.getNumericValue() )
                 pressAccuracy = accuracy.getNumericValue();
         }
-        if ( pressAccuracy > 5.0 )
-            throw new IllegalArgumentException("Unacceptably large accuracy in pressure measurements");
-        if ( autoSuggest.equals(DatasetQCStatus.Status.ACCEPTED_B) && (pressAccuracy > 2.0) )
-            autoSuggest = DatasetQCStatus.Status.ACCEPTED_C;
+        if ( pressAccuracy <= 2.0 ) {
+            comment += "Accuracy of pressure measurements 2.0 hPa or less";
+            if ( pressvars.size() > 1 )
+                comment += " (total accuracy using differential pressure instruments not considered)";
+            comment += ".  ";
+        }
+        else if ( pressAccuracy <= 5.0 ) {
+            comment += "Accuracy of pressure measurements between 2.0 and 5.0 hPa";
+            if ( pressvars.size() > 1 )
+                comment += " (total accuracy using differential pressure instruments not considered)";
+            comment += ".  ";
+            if ( autoSuggest.equals(DatasetQCStatus.Status.ACCEPTED_B) )
+                autoSuggest = DatasetQCStatus.Status.ACCEPTED_C;
+        }
+        else {
+            comment += "Accuracy of pressure measurements could not be determined or exceeds 5.0 hPa; " +
+                    "alternatve sensors (flag E) were not considered.";
+            DatasetQCStatus status = new DatasetQCStatus(DatasetQCStatus.Status.PRIVATE, comment);
+            status.setAutoSuggested(DatasetQCStatus.Status.SUSPENDED);
+            return status;
+        }
 
         int numNonZeroCalibGases = -1;
         int numCalibGases = -1;
@@ -346,10 +388,24 @@ public class OmeUtils {
         }
         // For ACCEPTED_B, at least two non-zero concentration calibration gases spanning entire range of fCO2 values
         // For ACCEPTED_C or ACCEPTED_D, at least two calibration gases, one of which can be zero concentration
-        if ( numCalibGases < 2 )
-            throw new IllegalArgumentException("Not enough calibration gases");
-        if ( numNonZeroCalibGases < 1 )
-            throw new IllegalArgumentException("Not enough non-zero concentration calibration gases");
+        if ( numCalibGases > 0 ) {
+            comment += numCalibGases + " calibration gasses";
+            if ( numNonZeroCalibGases >= 0 )
+                comment += " ," + numNonZeroCalibGases + " of which have non-zero concentrations";
+            comment += ".  ";
+        }
+        if ( numCalibGases < 2 ) {
+            comment += "Not enough calibration gasses.";
+            DatasetQCStatus status = new DatasetQCStatus(DatasetQCStatus.Status.PRIVATE, comment);
+            status.setAutoSuggested(DatasetQCStatus.Status.SUSPENDED);
+            return status;
+        }
+        if ( numNonZeroCalibGases < 1 ) {
+            comment += "Not enough non-zero concentration calibration gasses.";
+            DatasetQCStatus status = new DatasetQCStatus(DatasetQCStatus.Status.PRIVATE, comment);
+            status.setAutoSuggested(DatasetQCStatus.Status.SUSPENDED);
+            return status;
+        }
         if ( autoSuggest.equals(DatasetQCStatus.Status.ACCEPTED_B) && (numNonZeroCalibGases < 2) )
             autoSuggest = DatasetQCStatus.Status.ACCEPTED_C;
 
@@ -370,18 +426,25 @@ public class OmeUtils {
                 }
             }
         }
-        if ( !acceptable )
+        if ( !acceptable ) {
+            comment += "CO2 measurements not continuous or not made by a method recognized as acceptable.  ";
             autoSuggest = DatasetQCStatus.Status.ACCEPTED_D;
+        }
+
+        // TODO: If standardized data is provided, check acceptable ranges and variations
 
         // ACCEPTED_B must be:
         //     calibration gas concentrations spans the entire range of fCO2 values
         //     warming between SST and Tequ less than 1 deg C
-
         // ACCEPTED_C (not alternative sensor) must be either:
         //     [0.8,1.2] times the calibration gas concentrations spans the entire range of fCO2 values
         //     warming between SST and Tequ less than 3 deg C
 
-        return autoSuggest;
+        if ( autoSuggest.equals(DatasetQCStatus.Status.ACCEPTED_B) )
+            comment += "  No attempt was made to find high-quality crossovers.";
+        DatasetQCStatus status = new DatasetQCStatus(DatasetQCStatus.Status.PRIVATE, comment);
+        status.setAutoSuggested(autoSuggest);
+        return status;
     }
 
 }

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/metadata/OmeUtils.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/metadata/OmeUtils.java
@@ -272,11 +272,11 @@ public class OmeUtils {
         // the calibration, so an automation-suggested flag is not possible.  So failing to give
         // a flag (raising an exception) is an acceptable response.
 
-        // Accuracy of temperatures within 0.2 ºC (0.05 ºC for ACCEPTED_B)
+        // Accuracy of temperatures within 0.2 °C (0.05 °C for ACCEPTED_B)
         double tempAccuracy = 999.0;
         for (Temperature temperature : tempvars) {
             NumericString accuracy = temperature.getAccuracy();
-            // Temperature variables must units of ºC
+            // Temperature variables must units of °C
             if ( tempAccuracy > accuracy.getNumericValue() )
                 tempAccuracy = accuracy.getNumericValue();
         }

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/metadata/SdiOmeMetadata.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/metadata/SdiOmeMetadata.java
@@ -303,7 +303,7 @@ public class SdiOmeMetadata implements OmeMetadataInterface {
     }
 
     @Override
-    public DatasetQCStatus.Status suggestedDatasetStatus(DashboardDataset dataset) throws IllegalArgumentException {
+    public DatasetQCStatus suggestedDatasetStatus(DashboardDataset dataset) throws IllegalArgumentException {
         return OmeUtils.suggestDatasetQCFlag(mdata, dataset);
     }
 

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/server/DashboardServices.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/server/DashboardServices.java
@@ -300,7 +300,7 @@ public class DashboardServices extends RemoteServiceServlet implements Dashboard
 
             }
             ArrayList<QCEvent> qcEventList = new ArrayList<>(allRegionIds.length());
-            DatasetQCStatus flag = new DatasetQCStatus(DatasetQCStatus.Status.UPDATED_AWAITING_QC);
+            DatasetQCStatus flag = new DatasetQCStatus(DatasetQCStatus.Status.UPDATED_AWAITING_QC, comment);
             for (int k = 0; k < allRegionIds.length(); k++) {
                 QCEvent qcEvent = new QCEvent();
                 qcEvent.setDatasetId(datasetId);
@@ -590,7 +590,8 @@ public class DashboardServices extends RemoteServiceServlet implements Dashboard
         if ( !validateRequest(pageUsername) )
             throw new IllegalArgumentException("Invalid user request");
 
-        DatasetQCStatus flag = new DatasetQCStatus(DatasetQCStatus.Status.SUSPENDED);
+        String comment = "suspended for update from the SOCAT Dashboard";
+        DatasetQCStatus flag = new DatasetQCStatus(DatasetQCStatus.Status.SUSPENDED, comment);
         // Global suspend QC event to add to the database (after adding the dataset ID)
         QCEvent qc = new QCEvent();
         qc.setUsername(username);
@@ -598,7 +599,7 @@ public class DashboardServices extends RemoteServiceServlet implements Dashboard
         qc.setFlagDate(new Date());
         qc.setVersion(configStore.getQCVersion());
         qc.setRegionId(DashboardUtils.REGION_ID_GLOBAL);
-        qc.setComment("suspended for update from the SOCAT Dashboard");
+        qc.setComment(comment);
 
         DataFileHandler dataHandler = configStore.getDataFileHandler();
         DatabaseRequestHandler dbHandler = configStore.getDatabaseRequestHandler();

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/server/MetadataUploadService.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/server/MetadataUploadService.java
@@ -205,23 +205,22 @@ public class MetadataUploadService extends HttpServlet {
                         throw new IllegalArgumentException("Unable to create the PDF from the OME XML: " +
                                 ex.getMessage());
                     }
-                    DatasetQCStatus.Status autoSuggest;
+                    DatasetQCStatus autoSuggestedQC;
                     try {
-                        autoSuggest = omedata.suggestedDatasetStatus(dataset);
+                        autoSuggestedQC = omedata.suggestedDatasetStatus(dataset);
+                        DatasetQCStatus status = dataset.getSubmitStatus();
+                        if ( !autoSuggestedQC.getAutoSuggested().equals(status.getAutoSuggested()) ) {
+                            status.setAutoSuggested(autoSuggestedQC.getAutoSuggested());
+                            status.addComment(autoSuggestedQC.getComments().get(0));
+                            dataset.setSubmitStatus(status);
+                            dataFileHandler.saveDatasetInfoToFile(dataset,
+                                    "Update of automation-suggested dataset QC flag");
+                        }
                     } catch ( Exception ex ) {
                         /*
-                         * Either there is a problem with the metadata, the metadata indicates
-                         * the dataset is unacceptable, or the code to recommend a dataset QC
-                         * flag is faulty; whatever the reason, do not make a recommendation.
+                         * Either there is a problem with the metadata or the code to recommend
+                         * a dataset QC flag is faulty; whatever the reason, do not make a recommendation.
                          */
-                        autoSuggest = DatasetQCStatus.Status.PRIVATE;
-                    }
-                    DatasetQCStatus status = dataset.getSubmitStatus();
-                    if ( !autoSuggest.equals(status.getAutoSuggested()) ) {
-                        status.setAutoSuggested(autoSuggest);
-                        dataset.setSubmitStatus(status);
-                        dataFileHandler.saveDatasetInfoToFile(dataset,
-                                "Update of automation-suggested dataset QC flag");
                     }
                 }
                 else {

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/shared/DatasetQCStatus.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/shared/DatasetQCStatus.java
@@ -3,6 +3,7 @@ package gov.noaa.pmel.dashboard.shared;
 import com.google.gwt.user.client.rpc.IsSerializable;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 
@@ -13,7 +14,7 @@ import java.util.HashSet;
  */
 public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializable, IsSerializable {
 
-    private static final long serialVersionUID = 4778510861926574708L;
+    private static final long serialVersionUID = -5185613156609609049L;
 
     /**
      * Values for the DatasetQCStatus fields
@@ -230,7 +231,7 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
     private Status actual;
     private Status piSuggested;
     private Status autoSuggested;
-    private String comment;
+    private ArrayList<String> comments;
 
     /**
      * Create with all QC status fields set to {@link Status#PRIVATE} and no comment
@@ -239,7 +240,7 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
         actual = Status.PRIVATE;
         piSuggested = Status.PRIVATE;
         autoSuggested = Status.PRIVATE;
-        comment = "";
+        comments = new ArrayList<String>();
     }
 
     /**
@@ -251,14 +252,17 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
      *         actual dataset QC status to assign;
      *         if null, {@link Status#PRIVATE} is assigned
      * @param comment
-     *         comment associated with this flag; if null or empty, there will be no comment
+     *         comment associated with this flag; if null or empty, there will be no comments
      */
     public DatasetQCStatus(Status flag, String comment) {
         this();
         if ( flag != null )
             actual = flag;
-        if ( comment != null )
-            this.comment = comment.trim();
+        if ( comment != null ) {
+            String trimmedComment = comment.trim();
+            if ( !trimmedComment.isEmpty() )
+                comments.add(trimmedComment);
+        }
     }
 
     /**
@@ -275,7 +279,8 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
             actual = qcFlag.actual;
             piSuggested = qcFlag.piSuggested;
             autoSuggested = qcFlag.autoSuggested;
-            comment = qcFlag.comment;
+            comments.clear();
+            comments.addAll(qcFlag.comments);
         }
     }
 
@@ -334,22 +339,45 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
     }
 
     /**
-     * @return the comment associated with this QC; never null but could be empty
+     * @return a copy of the list of comments associated with this QC; never null but could be empty
      */
-    public String getComment() {
-        return comment;
+    public ArrayList<String> getComments() {
+        return new ArrayList<String>(comments);
+    }
+
+    /**
+     * @param comments
+     *         the comments associated with this QC to assign;
+     *         if null or empty, there will be no comments associated with this QC.
+     *         Any null or blank comments will be ignored.
+     */
+    public void setComments(ArrayList<String> comments) {
+        this.comments.clear();
+        if ( comments != null ) {
+            for (String comment : comments) {
+                if ( comment != null ) {
+                    comment = comment.trim();
+                    if ( !comment.isEmpty() )
+                        this.comments.add(comment);
+                }
+            }
+        }
     }
 
     /**
      * @param comment
-     *         the comment associated with this QC to assign;
-     *         if null or empty, there will be no comment associated with this QC
+     *         comment to add to the beginning of the list of comments (so the latest comments are seen first).
+     *
+     * @throws IllegalArgumentException
+     *         if comment is null or blank
      */
-    public void setComment(String comment) {
+    public void addComment(String comment) throws IllegalArgumentException {
         if ( comment == null )
-            this.comment = "";
-        else
-            this.comment = comment.trim();
+            throw new IllegalArgumentException("null comment given to addComment");
+        String trimmedComment = comment.trim();
+        if ( trimmedComment.isEmpty() )
+            throw new IllegalArgumentException("blank comment given to addComment");
+        comments.add(0, trimmedComment);
     }
 
     /**
@@ -580,9 +608,15 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
         value = piSuggested.compareTo(other.piSuggested);
         if ( value != 0 )
             return value;
-        value = comment.compareTo(other.comment);
+        Integer numComments = comments.size();
+        value = numComments.compareTo(other.comments.size());
         if ( value != 0 )
             return value;
+        for (int k = 0; k < numComments; k++) {
+            value = comments.get(k).compareTo(other.comments.get(k));
+            if ( value != 0 )
+                return value;
+        }
         return 0;
     }
 
@@ -601,9 +635,8 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
             return false;
         if ( !piSuggested.equals(other.piSuggested) )
             return false;
-        if ( !comment.equals(other.comment) )
+        if ( !comments.equals(other.comments) )
             return false;
-
         return true;
     }
 
@@ -613,7 +646,7 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
         int value = actual.hashCode();
         value = value * prime + autoSuggested.hashCode();
         value = value * prime + piSuggested.hashCode();
-        value = value * prime + comment.hashCode();
+        value = value * prime + comments.hashCode();
         return value;
     }
 
@@ -623,7 +656,7 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
                 "[ actual=" + actual +
                 ", autoSuggested=" + autoSuggested +
                 ", piSuggested=" + piSuggested +
-                ", comment=" + comment +
+                ", comments=" + comments.toString() +
                 " ]";
     }
 

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/shared/DatasetQCStatus.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/shared/DatasetQCStatus.java
@@ -13,7 +13,7 @@ import java.util.HashSet;
  */
 public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializable, IsSerializable {
 
-    private static final long serialVersionUID = -2087355116417187766L;
+    private static final long serialVersionUID = 4778510861926574708L;
 
     /**
      * Values for the DatasetQCStatus fields
@@ -230,28 +230,35 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
     private Status actual;
     private Status piSuggested;
     private Status autoSuggested;
+    private String comment;
 
     /**
-     * Create with all QC status fields set to {@link Status#PRIVATE}
+     * Create with all QC status fields set to {@link Status#PRIVATE} and no comment
      */
     public DatasetQCStatus() {
         actual = Status.PRIVATE;
         piSuggested = Status.PRIVATE;
         autoSuggested = Status.PRIVATE;
+        comment = "";
     }
 
     /**
      * Create with the given Status as the actual QC status field.
+     * The given comment is assigned as the comment associated with this flag.
      * The PI-suggested and automation-suggested fields are set to {@link Status#PRIVATE}
      *
      * @param flag
      *         actual dataset QC status to assign;
      *         if null, {@link Status#PRIVATE} is assigned
+     * @param comment
+     *         comment associated with this flag; if null or empty, there will be no comment
      */
-    public DatasetQCStatus(Status flag) {
+    public DatasetQCStatus(Status flag, String comment) {
         this();
         if ( flag != null )
             actual = flag;
+        if ( comment != null )
+            this.comment = comment.trim();
     }
 
     /**
@@ -268,6 +275,7 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
             actual = qcFlag.actual;
             piSuggested = qcFlag.piSuggested;
             autoSuggested = qcFlag.autoSuggested;
+            comment = qcFlag.comment;
         }
     }
 
@@ -323,6 +331,25 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
             autoSuggested = Status.PRIVATE;
         else
             autoSuggested = flag;
+    }
+
+    /**
+     * @return the comment associated with this QC; never null but could be empty
+     */
+    public String getComment() {
+        return comment;
+    }
+
+    /**
+     * @param comment
+     *         the comment associated with this QC to assign;
+     *         if null or empty, there will be no comment associated with this QC
+     */
+    public void setComment(String comment) {
+        if ( comment == null )
+            this.comment = "";
+        else
+            this.comment = comment.trim();
     }
 
     /**
@@ -553,7 +580,9 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
         value = piSuggested.compareTo(other.piSuggested);
         if ( value != 0 )
             return value;
-
+        value = comment.compareTo(other.comment);
+        if ( value != 0 )
+            return value;
         return 0;
     }
 
@@ -572,6 +601,8 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
             return false;
         if ( !piSuggested.equals(other.piSuggested) )
             return false;
+        if ( !comment.equals(other.comment) )
+            return false;
 
         return true;
     }
@@ -582,6 +613,7 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
         int value = actual.hashCode();
         value = value * prime + autoSuggested.hashCode();
         value = value * prime + piSuggested.hashCode();
+        value = value * prime + comment.hashCode();
         return value;
     }
 
@@ -591,6 +623,7 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
                 "[ actual=" + actual +
                 ", autoSuggested=" + autoSuggested +
                 ", piSuggested=" + piSuggested +
+                ", comment=" + comment +
                 " ]";
     }
 

--- a/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/metadata/OmeUtilsTest.java
+++ b/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/metadata/OmeUtilsTest.java
@@ -250,7 +250,7 @@ public class OmeUtilsTest {
             "    </CO2_in_Marine_Air>\n" +
             "    <CO2_Sensors>\n" +
             "      <CO2_Sensor>\n" +
-            "        <Measurement_Method>IR</Measurement_Method>\n" +
+            "        <Measurement_Method> ... IR ... </Measurement_Method>\n" +
             "        <Manufacturer>LI-COR</Manufacturer>\n" +
             "        <Model>7000</Model>\n" +
             "        <Frequency>Every 140 seconds, except during calibration</Frequency>\n" +

--- a/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/metadata/OmeUtilsTest.java
+++ b/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/metadata/OmeUtilsTest.java
@@ -40,13 +40,13 @@ public class OmeUtilsTest {
         }
         assertNotNull(mdata);
 
-        DatasetQCStatus.Status status = null;
+        DatasetQCStatus status = null;
         try {
             status = OmeUtils.suggestDatasetQCFlag(mdata, dset);
         } catch ( Exception ex ) {
             fail("Unable to make an automation-suggested dataset QC flag: " + ex.getMessage());
         }
-        assertEquals(DatasetQCStatus.Status.ACCEPTED_B, status);
+        assertEquals(DatasetQCStatus.Status.ACCEPTED_B, status.getAutoSuggested());
     }
 
     private static final ArrayList<String> DATA_COLUMN_NAMES = new ArrayList<String>(Arrays.asList(

--- a/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/shared/DashboardDatasetTest.java
+++ b/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/shared/DashboardDatasetTest.java
@@ -152,7 +152,7 @@ public class DashboardDatasetTest {
     @Test
     public void testSetGetSubmitStatus() {
         DatasetQCStatus emptyFlag = new DatasetQCStatus();
-        DatasetQCStatus mySubmitStatus = new DatasetQCStatus(DatasetQCStatus.Status.UPDATED_AWAITING_QC);
+        DatasetQCStatus mySubmitStatus = new DatasetQCStatus(DatasetQCStatus.Status.UPDATED_AWAITING_QC, "");
         mySubmitStatus.setPiSuggested(DatasetQCStatus.Status.ACCEPTED_A);
         mySubmitStatus.setAutoSuggested(DatasetQCStatus.Status.ACCEPTED_B);
         DashboardDataset cruise = new DashboardDataset();
@@ -499,7 +499,7 @@ public class DashboardDatasetTest {
                 "ABCD20050728.txt; 2014-02-21 9:23",
                 "ABCD20050728_2.doc; 2014-02-21 9:24",
                 "ABCD20050728_3.pdf; 2014-02-21 9:25"));
-        DatasetQCStatus mySubmitStatus = new DatasetQCStatus(DatasetQCStatus.Status.UPDATED_AWAITING_QC);
+        DatasetQCStatus mySubmitStatus = new DatasetQCStatus(DatasetQCStatus.Status.UPDATED_AWAITING_QC, "");
         mySubmitStatus.setPiSuggested(DatasetQCStatus.Status.ACCEPTED_A);
         mySubmitStatus.setAutoSuggested(DatasetQCStatus.Status.ACCEPTED_B);
         String myArchiveStatus = "Next SOCAT release";

--- a/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/shared/DatasetQCStatusTest.java
+++ b/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/shared/DatasetQCStatusTest.java
@@ -15,6 +15,7 @@ public class DatasetQCStatusTest {
     private static final DatasetQCStatus.Status ACTUAL_FLAG = DatasetQCStatus.Status.UPDATED_AWAITING_QC;
     private static final DatasetQCStatus.Status PI_FLAG = DatasetQCStatus.Status.ACCEPTED_A;
     private static final DatasetQCStatus.Status AUTO_FLAG = DatasetQCStatus.Status.ACCEPTED_B;
+    private static final String COMMENT_STRING = "This is a comment about the QC flag";
 
     /**
      * Test of {@link DatasetQCStatus#getActual()} and {@link DatasetQCStatus#setActual(DatasetQCStatus.Status)}
@@ -56,6 +57,22 @@ public class DatasetQCStatusTest {
         assertEquals(DEFAULT_FLAG, flag.getActual());
         flag.setAutoSuggested(null);
         assertEquals(DEFAULT_FLAG, flag.getAutoSuggested());
+    }
+
+    /**
+     * Test of {@link DatasetQCStatus#getComment()} and {@link DatasetQCStatus#setComment(String)}
+     */
+    @Test
+    public void testGetSetComment() {
+        DatasetQCStatus flag = new DatasetQCStatus();
+        assertEquals("", flag.getComment());
+        flag.setComment(COMMENT_STRING);
+        assertEquals(COMMENT_STRING, flag.getComment());
+        assertEquals(DEFAULT_FLAG, flag.getAutoSuggested());
+        assertEquals(DEFAULT_FLAG, flag.getPiSuggested());
+        assertEquals(DEFAULT_FLAG, flag.getActual());
+        flag.setComment(null);
+        assertEquals("", flag.getComment());
     }
 
     /**
@@ -111,7 +128,7 @@ public class DatasetQCStatusTest {
         assertEquals(PI_FLAG, DatasetQCStatus.Status.fromString(PI_FLAG.toString()));
         assertEquals(AUTO_FLAG, DatasetQCStatus.Status.fromString(AUTO_FLAG.toString()));
 
-        DatasetQCStatus flag = new DatasetQCStatus(ACTUAL_FLAG);
+        DatasetQCStatus flag = new DatasetQCStatus(ACTUAL_FLAG, "");
         String flagString = flag.flagString();
         DatasetQCStatus other = DatasetQCStatus.fromString(flagString);
         assertEquals(flag, other);
@@ -317,7 +334,6 @@ public class DatasetQCStatusTest {
         assertFalse(flag.isUpdatedAwaitingQC());
     }
 
-
     /**
      * Test of {@link DatasetQCStatus#compareTo(DatasetQCStatus)}
      */
@@ -334,6 +350,7 @@ public class DatasetQCStatusTest {
 
         first.setPiSuggested(PI_FLAG);
         first.setAutoSuggested(AUTO_FLAG);
+        first.setComment(COMMENT_STRING);
         assertTrue(first.compareTo(second) > 0);
         assertTrue(second.compareTo(first) < 0);
 
@@ -346,6 +363,10 @@ public class DatasetQCStatusTest {
         assertTrue(second.compareTo(first) < 0);
 
         second.setAutoSuggested(AUTO_FLAG);
+        assertTrue(first.compareTo(second) > 0);
+        assertTrue(second.compareTo(first) < 0);
+
+        second.setComment(COMMENT_STRING);
         assertEquals(0, first.compareTo(second));
         assertEquals(0, second.compareTo(first));
 
@@ -389,22 +410,30 @@ public class DatasetQCStatusTest {
         second.setAutoSuggested(AUTO_FLAG);
         assertEquals(first.hashCode(), second.hashCode());
         assertTrue(first.equals(second));
+
+        first.setComment(COMMENT_STRING);
+        assertNotEquals(first.hashCode(), second.hashCode());
+        assertFalse(first.equals(second));
+        second.setComment(COMMENT_STRING);
+        assertEquals(first.hashCode(), second.hashCode());
+        assertTrue(first.equals(second));
     }
 
     /**
-     * Test of {@link DatasetQCStatus#DatasetQCStatus(DatasetQCStatus.Status)}
+     * Test of {@link DatasetQCStatus#DatasetQCStatus(DatasetQCStatus.Status, String)}
      * and {@link DatasetQCStatus#DatasetQCStatus(DatasetQCStatus)}
      */
     @Test
     public void testDatasetQCFlag() {
         DatasetQCStatus flag = new DatasetQCStatus();
-        DatasetQCStatus other = new DatasetQCStatus((DatasetQCStatus.Status) null);
+        DatasetQCStatus other = new DatasetQCStatus((DatasetQCStatus.Status) null, "");
         assertEquals(flag, other);
         other = new DatasetQCStatus((DatasetQCStatus) null);
         assertEquals(flag, other);
 
         flag.setActual(ACTUAL_FLAG);
-        other = new DatasetQCStatus(ACTUAL_FLAG);
+        flag.setComment(COMMENT_STRING);
+        other = new DatasetQCStatus(ACTUAL_FLAG, COMMENT_STRING);
         assertEquals(flag, other);
 
         flag.setPiSuggested(PI_FLAG);

--- a/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/shared/DatasetQCStatusTest.java
+++ b/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/shared/DatasetQCStatusTest.java
@@ -3,9 +3,13 @@ package gov.noaa.pmel.dashboard.test.shared;
 import gov.noaa.pmel.dashboard.shared.DatasetQCStatus;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -15,7 +19,10 @@ public class DatasetQCStatusTest {
     private static final DatasetQCStatus.Status ACTUAL_FLAG = DatasetQCStatus.Status.UPDATED_AWAITING_QC;
     private static final DatasetQCStatus.Status PI_FLAG = DatasetQCStatus.Status.ACCEPTED_A;
     private static final DatasetQCStatus.Status AUTO_FLAG = DatasetQCStatus.Status.ACCEPTED_B;
-    private static final String COMMENT_STRING = "This is a comment about the QC flag";
+    private static final String FIRST_COMMENT_STRING = "This is a comment about the QC flag";
+    private static final String SECOND_COMMENT_STRING = "This is another comment about the QC flag";
+    private static final ArrayList<String> COMMENTS_LIST =
+            new ArrayList<String>(Arrays.asList(SECOND_COMMENT_STRING, FIRST_COMMENT_STRING));
 
     /**
      * Test of {@link DatasetQCStatus#getActual()} and {@link DatasetQCStatus#setActual(DatasetQCStatus.Status)}
@@ -60,19 +67,25 @@ public class DatasetQCStatusTest {
     }
 
     /**
-     * Test of {@link DatasetQCStatus#getComment()} and {@link DatasetQCStatus#setComment(String)}
+     * Test of {@link DatasetQCStatus#getComments()}, {@link DatasetQCStatus#setComments(java.util.ArrayList)},
+     * and {@link DatasetQCStatus#addComment(String)}
      */
     @Test
-    public void testGetSetComment() {
+    public void testGetSetComments() {
         DatasetQCStatus flag = new DatasetQCStatus();
-        assertEquals("", flag.getComment());
-        flag.setComment(COMMENT_STRING);
-        assertEquals(COMMENT_STRING, flag.getComment());
+        assertEquals(0, flag.getComments().size());
+        flag.setComments(COMMENTS_LIST);
+        ArrayList<String> comments = flag.getComments();
+        assertNotSame(comments, flag.getComments());
+        assertEquals(COMMENTS_LIST, comments);
         assertEquals(DEFAULT_FLAG, flag.getAutoSuggested());
         assertEquals(DEFAULT_FLAG, flag.getPiSuggested());
         assertEquals(DEFAULT_FLAG, flag.getActual());
-        flag.setComment(null);
-        assertEquals("", flag.getComment());
+        flag.setComments(null);
+        assertEquals(0, flag.getComments().size());
+        flag.addComment(FIRST_COMMENT_STRING);
+        flag.addComment(SECOND_COMMENT_STRING);
+        assertEquals(COMMENTS_LIST, flag.getComments());
     }
 
     /**
@@ -350,7 +363,7 @@ public class DatasetQCStatusTest {
 
         first.setPiSuggested(PI_FLAG);
         first.setAutoSuggested(AUTO_FLAG);
-        first.setComment(COMMENT_STRING);
+        first.setComments(COMMENTS_LIST);
         assertTrue(first.compareTo(second) > 0);
         assertTrue(second.compareTo(first) < 0);
 
@@ -366,7 +379,7 @@ public class DatasetQCStatusTest {
         assertTrue(first.compareTo(second) > 0);
         assertTrue(second.compareTo(first) < 0);
 
-        second.setComment(COMMENT_STRING);
+        second.setComments(COMMENTS_LIST);
         assertEquals(0, first.compareTo(second));
         assertEquals(0, second.compareTo(first));
 
@@ -411,10 +424,10 @@ public class DatasetQCStatusTest {
         assertEquals(first.hashCode(), second.hashCode());
         assertTrue(first.equals(second));
 
-        first.setComment(COMMENT_STRING);
+        first.setComments(COMMENTS_LIST);
         assertNotEquals(first.hashCode(), second.hashCode());
         assertFalse(first.equals(second));
-        second.setComment(COMMENT_STRING);
+        second.setComments(COMMENTS_LIST);
         assertEquals(first.hashCode(), second.hashCode());
         assertTrue(first.equals(second));
     }
@@ -432,8 +445,8 @@ public class DatasetQCStatusTest {
         assertEquals(flag, other);
 
         flag.setActual(ACTUAL_FLAG);
-        flag.setComment(COMMENT_STRING);
-        other = new DatasetQCStatus(ACTUAL_FLAG, COMMENT_STRING);
+        flag.addComment(FIRST_COMMENT_STRING);
+        other = new DatasetQCStatus(ACTUAL_FLAG, FIRST_COMMENT_STRING);
         assertEquals(flag, other);
 
         flag.setPiSuggested(PI_FLAG);

--- a/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/shared/TypesDatasetDataPairTest.java
+++ b/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/shared/TypesDatasetDataPairTest.java
@@ -50,7 +50,7 @@ public class TypesDatasetDataPairTest {
     public void testGetSetDatasetData() {
         DashboardDatasetData cruiseData = new DashboardDatasetData();
         cruiseData.setDatasetId("ABCD20161003");
-        cruiseData.setSubmitStatus(new DatasetQCStatus(DatasetQCStatus.Status.SUSPENDED));
+        cruiseData.setSubmitStatus(new DatasetQCStatus(DatasetQCStatus.Status.SUSPENDED, ""));
 
         TypesDatasetDataPair cruiseTypes = new TypesDatasetDataPair();
         assertNull(cruiseTypes.getDatasetData());
@@ -75,7 +75,7 @@ public class TypesDatasetDataPairTest {
 
         DashboardDatasetData cruiseData = new DashboardDatasetData();
         cruiseData.setDatasetId("ABCD20161003");
-        cruiseData.setSubmitStatus(new DatasetQCStatus(DatasetQCStatus.Status.SUSPENDED));
+        cruiseData.setSubmitStatus(new DatasetQCStatus(DatasetQCStatus.Status.SUSPENDED, ""));
 
         TypesDatasetDataPair cruiseTypes = new TypesDatasetDataPair();
         assertFalse(cruiseTypes.equals(null));


### PR DESCRIPTION
Automated metadata QC returns a DatasetQCStatus returned with autoSuggested and a single comment set.  DatasetQCStatus contains an ArrayList of comments to allow for cleaner separation of QC comments by different users/processes.  If metadata incomplete or contains unacceptable values, recommends a suspend instead of throwing an exception.