### PR TITLE
Only assign actual dataset QC flag to DSG files

### DIFF
--- a/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/UpdateQCFlags.java
+++ b/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/UpdateQCFlags.java
@@ -3,6 +3,7 @@ package gov.noaa.pmel.dashboard.programs;
 import gov.noaa.pmel.dashboard.handlers.DatabaseRequestHandler;
 import gov.noaa.pmel.dashboard.handlers.DsgNcFileHandler;
 import gov.noaa.pmel.dashboard.server.DashboardConfigStore;
+import gov.noaa.pmel.dashboard.shared.DatasetQCStatus;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -74,10 +75,12 @@ public class UpdateQCFlags {
 
             // update each of these cruises
             for (String expocode : allExpocodes) {
+                DatasetQCStatus qcStatus;
                 String qcFlag;
                 String versionStatus;
                 try {
-                    qcFlag = dbHandler.getDatasetQCFlag(expocode).flagString();
+                    qcStatus = dbHandler.getDatasetQCFlag(expocode);
+                    qcFlag = qcStatus.dsgFlagString();
                     versionStatus = dbHandler.getVersionStatus(expocode);
                 } catch ( Exception ex ) {
                     System.err.println("Error getting the database QC flag or version with status for " +
@@ -100,7 +103,7 @@ public class UpdateQCFlags {
                 try {
                     if ( !(qcFlag.equals(oldQCFlag) && versionStatus.equals(oldVersionStatus)) ) {
                         // Update the QC flag in the DSG files
-                        dsgHandler.updateDatasetQCFlagAndVersionStatus(expocode, qcFlag, versionStatus);
+                        dsgHandler.updateDatasetQCFlagAndVersionStatus(expocode, qcStatus, versionStatus);
                         System.out.println("Updated QC flag for " + expocode + " from '" + oldQCFlag +
                                 "', v" + oldVersionStatus + " to '" + qcFlag + "', v" + versionStatus);
 

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/client/DataUploadPage.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/client/DataUploadPage.java
@@ -51,15 +51,16 @@ public class DataUploadPage extends CompositeWithUsername {
                     "<li>a line of data column units (optional),</li>" +
                     "<li>a line of data values for each data sample</li>" +
                     "</ul></p>" +
-                    "<p>The expocode, vessel (ship) name, and investigators " +
-                    "names must be given (organization and vessel type are optional) " +
+                    "<p>The expocode, vessel (ship) name, and investigators names must be given " +
+                    "(organization, vessel type, and suggest flag are optional) " +
                     "in either the metadata lines (# at start is optional): " +
                     "<ul style=\"list-style-type: none\">" +
-                    "<li># expocode: ZZZZ20051231</li>" +
-                    "<li># vessel name: Pacific Minnow</li>" +
+                    "<li># Expocode: ZZZZ20051231</li>" +
+                    "<li># Vessel name: Pacific Minnow</li>" +
                     "<li># PIs: Smith, K.; Doe, J.</li>" +
                     "<li># Org: Ocean Tours</li>" +
-                    "<li># vessel type: Ship</li>" +
+                    "<li># Vessel type: Ship</li>" +
+                    "<li># Suggested QC: C</li>" +
                     "</ul> " +
                     "or they can be in columns with appropriate names.  </p>";
 
@@ -73,6 +74,7 @@ public class DataUploadPage extends CompositeWithUsername {
                     "  <li>PI: Wanninkhof, R.</li>" +
                     "  <li>Org: NOAA-AOML</li>" +
                     "  <li>Vessel Type: Ship</li>" +
+                    "  <li>Suggested QC: B</li>" +
                     "  <li></li>" +
                     "  <li>CruiseID,JD_GMT,DATE_UTC__ddmmyyyy,TIME_UTC_hh:mm:ss,LAT_dec_degree,LONG_dec_degree,...</li>" +
                     "  <li>20-01B,110.79219,19042012,19:00:45,12.638,-59.239,...</li>" +
@@ -107,6 +109,7 @@ public class DataUploadPage extends CompositeWithUsername {
                     "Tags for the vessel type are 'vessel type', 'platform type', or just " +
                     "'type'.  If the vessel type is not specified, an intelligent guess is " +
                     "made based on the vessel name and/or the NODC code part of the expocode.  " +
+                    "Tags for the PI-suggest dataset QC flag are 'PI-suggested QC', 'Suggested QC', or 'PI QC'." +
                     "</p><p>" +
                     "Units for the columns can be given on a second column header line, " +
                     "such as the following:" +
@@ -116,6 +119,7 @@ public class DataUploadPage extends CompositeWithUsername {
                     "  <li>Investigator = Wanninkhof, R.</li>" +
                     "  <li>Organization = NOAA-AOML</li>" +
                     "  <li>Vessel Type = Ship</li>" +
+                    "  <li>PI-suggested QC: B</li>" +
                     "  <li></li>" +
                     "  <li>CruiseID,JD_GMT,DATE_UTC,TIME_UTC,LAT,LONG,...</li>" +
                     "  <li>,Jan1=1,ddmmyyyy,hh:mm:ss,dec.deg.,dec.deg.,...</li>" +
@@ -626,7 +630,8 @@ public class DataUploadPage extends CompositeWithUsername {
             }
             else if ( header.startsWith(DashboardUtils.INVALID_SUGGESTED_QC_STATUS_HEADER_TAG) ) {
                 // Invalid entry for organization names
-                String filename = header.substring(DashboardUtils.INVALID_SUGGESTED_QC_STATUS_HEADER_TAG.length()).trim();
+                String filename = header.substring(DashboardUtils.INVALID_SUGGESTED_QC_STATUS_HEADER_TAG.length())
+                                        .trim();
                 errMsgs.add(FAIL_MSG_START + SafeHtmlUtils.htmlEscape(filename) + INVALID_SUGGESTED_QC_STATUS_FAIL_MSG);
             }
             else if ( header.startsWith(DashboardUtils.DATASET_EXISTS_HEADER_TAG) ) {

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/dsg/DsgNcFile.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/dsg/DsgNcFile.java
@@ -10,6 +10,7 @@ import gov.noaa.pmel.dashboard.qc.DataLocation;
 import gov.noaa.pmel.dashboard.qc.DataQCEvent;
 import gov.noaa.pmel.dashboard.server.DashboardServerUtils;
 import gov.noaa.pmel.dashboard.shared.DashboardUtils;
+import gov.noaa.pmel.dashboard.shared.DatasetQCStatus;
 import ucar.ma2.ArrayChar;
 import ucar.ma2.ArrayDouble;
 import ucar.ma2.ArrayInt;
@@ -33,7 +34,7 @@ import java.util.TreeSet;
 
 public class DsgNcFile extends File {
 
-    private static final long serialVersionUID = 1251710644553980018L;
+    private static final long serialVersionUID = 9104295509280903806L;
 
     private static final String DSG_VERSION = "DsgNcFile 2.0";
     private static final String TIME_ORIGIN_ATTRIBUTE = "01-JAN-1970 00:00:00";
@@ -952,8 +953,8 @@ public class DsgNcFile extends File {
     /**
      * Updates this DSG file with the given QC flag and version number with status
      *
-     * @param qcFlag
-     *         the QC flag to assign
+     * @param qcStatus
+     *         dataset QC status to use to assign the dataset QC flag in this DSG file
      * @param versionStatus
      *         version with status to assign
      *
@@ -962,7 +963,7 @@ public class DsgNcFile extends File {
      * @throws IOException
      *         if opening or writing to the DSG file throws one
      */
-    public void updateDatasetQCFlagAndVersionStatus(String qcFlag, String versionStatus)
+    public void updateDatasetQCFlagAndVersionStatus(DatasetQCStatus qcStatus, String versionStatus)
             throws IllegalArgumentException, IOException {
         NetcdfFileWriter ncfile = NetcdfFileWriter.openExisting(getPath());
         try {
@@ -971,7 +972,7 @@ public class DsgNcFile extends File {
             if ( var == null )
                 throw new IllegalArgumentException("Unable to find variable '" + varName + "' in " + getName());
             ArrayChar.D2 flagArray = new ArrayChar.D2(1, var.getShape(1));
-            flagArray.setString(0, qcFlag.trim());
+            flagArray.setString(0, qcStatus.dsgFlagString());
             try {
                 ncfile.write(var, flagArray);
             } catch ( InvalidRangeException ex ) {

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/handlers/DsgNcFileHandler.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/handlers/DsgNcFileHandler.java
@@ -11,6 +11,7 @@ import gov.noaa.pmel.dashboard.qc.DataLocation;
 import gov.noaa.pmel.dashboard.qc.DataQCEvent;
 import gov.noaa.pmel.dashboard.server.DashboardServerUtils;
 import gov.noaa.pmel.dashboard.shared.DashboardUtils;
+import gov.noaa.pmel.dashboard.shared.DatasetQCStatus;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
@@ -530,8 +531,8 @@ public class DsgNcFileHandler {
      *
      * @param datasetId
      *         update the dataset DSG files with this unique ID (expocode)
-     * @param qcFlag
-     *         dataset QC flag to assign in the DSG files
+     * @param qcStatus
+     *         dataset QC status to use to assign the dataset QC flag in the DSG file
      * @param versionStatus
      *         version with status (e.g., "2019.0N") to assign in the DSG files
      *
@@ -540,19 +541,19 @@ public class DsgNcFileHandler {
      * @throws IOException
      *         if problems opening or writing to a DSG file
      */
-    public void updateDatasetQCFlagAndVersionStatus(String datasetId, String qcFlag, String versionStatus)
+    public void updateDatasetQCFlagAndVersionStatus(String datasetId, DatasetQCStatus qcStatus, String versionStatus)
             throws IllegalArgumentException, IOException {
         // Get the location and name for the NetCDF DSG file
         DsgNcFile dsgFile = getDsgNcFile(datasetId);
         if ( !dsgFile.exists() )
             throw new IllegalArgumentException("Full-data DSG file for " + datasetId + " does not exist");
         synchronized(SINGLETON_SYNC_OBJECT) {
-            dsgFile.updateDatasetQCFlagAndVersionStatus(qcFlag, versionStatus);
+            dsgFile.updateDatasetQCFlagAndVersionStatus(qcStatus, versionStatus);
         }
         DsgNcFile decDsgFile = getDecDsgNcFile(datasetId);
         if ( !decDsgFile.exists() )
             throw new IllegalArgumentException("Decimated DSG file for " + datasetId + " does not exist");
-        decDsgFile.updateDatasetQCFlagAndVersionStatus(qcFlag, versionStatus);
+        decDsgFile.updateDatasetQCFlagAndVersionStatus(qcStatus, versionStatus);
         flagErddap(true, true);
     }
 

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/server/DashboardServices.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/server/DashboardServices.java
@@ -324,7 +324,7 @@ public class DashboardServices extends RemoteServiceServlet implements Dashboard
                 dataHandler.saveDatasetInfoToFile(dataset, comment);
                 // Update the DSG files
                 String versionStatus = dbHandler.getVersionStatus(datasetId);
-                dsgHandler.updateDatasetQCFlagAndVersionStatus(datasetId, flag.flagString(), versionStatus);
+                dsgHandler.updateDatasetQCFlagAndVersionStatus(datasetId, flag, versionStatus);
                 itsLogger.info("updated QC status for " + datasetId);
             } catch ( Exception ex ) {
                 // Should not fail.  If does, record but otherwise ignore the failure.
@@ -621,7 +621,7 @@ public class DashboardServices extends RemoteServiceServlet implements Dashboard
                     dataHandler.saveDatasetInfoToFile(dset, message);
                     //  update the DSG files
                     String versionStatus = dbHandler.getVersionStatus(datasetId);
-                    dsgHandler.updateDatasetQCFlagAndVersionStatus(datasetId, status.flagString(), versionStatus);
+                    dsgHandler.updateDatasetQCFlagAndVersionStatus(datasetId, status, versionStatus);
                     itsLogger.info(message);
                 }
             } catch ( Exception ex ) {

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/server/MetadataUploadService.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/server/MetadataUploadService.java
@@ -242,7 +242,7 @@ public class MetadataUploadService extends HttpServlet {
                         dataFileHandler.saveDatasetInfoToFile(dataset, comment);
                         // Update the DSG files
                         String versionStatus = databaseHandler.getVersionStatus(id);
-                        dsgHandler.updateDatasetQCFlagAndVersionStatus(id, status.flagString(), versionStatus);
+                        dsgHandler.updateDatasetQCFlagAndVersionStatus(id, status, versionStatus);
                     } catch ( Exception ex ) {
                         // Should not fail. If does, do not delete the file since it is okay;
                         // just record but otherwise ignore the failure.

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/shared/DatasetQCStatus.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/shared/DatasetQCStatus.java
@@ -14,7 +14,7 @@ import java.util.HashSet;
  */
 public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializable, IsSerializable {
 
-    private static final long serialVersionUID = -5185613156609609049L;
+    private static final long serialVersionUID = 8281099561773635785L;
 
     /**
      * Values for the DatasetQCStatus fields
@@ -419,6 +419,22 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
                 throw new IllegalArgumentException("Invalid automation-suggested QC status " + autoSuggested);
             valueString += FLAG_SEPARATOR + AUTOFLAG_PREFIX + autoVal;
         }
+        return valueString;
+    }
+
+    /**
+     * @return the dataset QC status flag to assign as to the DSG file; never null or empty.
+     *         At this time, just the actual status flag string (N, U, A, B, C, D, E, Q, S, X)
+     *
+     * @throws IllegalArgumentException
+     *         if the QC status is invalid for assigning to a DSG file
+     */
+    public String dsgFlagString() throws IllegalArgumentException {
+        if ( Status.PRIVATE.equals(actual) || Status.RENAMED.equals(actual) || Status.COMMENT.equals(actual) )
+            throw new IllegalArgumentException("Invalid actual QC status " + actual + " for DSG files");
+        String valueString = STATUS_FLAG_MAP.get(actual);
+        if ( valueString == null )
+            throw new IllegalArgumentException("Unknown actual QC status " + actual);
         return valueString;
     }
 

--- a/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/actualdatamodified/SubmitProcessTest.java
+++ b/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/actualdatamodified/SubmitProcessTest.java
@@ -196,7 +196,7 @@ public class SubmitProcessTest {
             qc.setDatasetId(EXPOCODE);
             dbHandler.addDatasetQCEvents(Collections.singletonList(qc));
             datasetHandler.saveDatasetInfoToFile(dataset, comment);
-            dsgHandler.updateDatasetQCFlagAndVersionStatus(EXPOCODE, flag.flagString(), version + "N");
+            dsgHandler.updateDatasetQCFlagAndVersionStatus(EXPOCODE, flag, version + "N");
         } catch ( Exception ex ) {
             System.err.println("Problems suspending " + EXPOCODE + " from QC: " + ex.getMessage());
             ex.printStackTrace();


### PR DESCRIPTION
The PI-suggested and automation-suggested dataset QC flag additions cause many options for LAS.  While desirable (give me all new datasets with automation-suggested  QC of B), this need to be simplified in LAS to select all N* and U* datasets without adding dozens of N and U flag combinations.

Also add information to upload page about PI-suggested dataset QC flag