### PR TITLE
Enable platform types fixes and do not overwrite orgs; support old flag F

### DIFF
--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/metadata/DashboardOmeMetadata.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/metadata/DashboardOmeMetadata.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package gov.noaa.pmel.dashboard.metadata;
 
 import gov.noaa.pmel.dashboard.datatype.KnownDataTypes;
@@ -27,7 +24,7 @@ import java.util.TimeZone;
  */
 public class DashboardOmeMetadata extends DashboardMetadata {
 
-    private static final long serialVersionUID = 353927270709646644L;
+    private static final long serialVersionUID = 6113847974011933801L;
 
     /**
      * String separating each PI listed in scienceGroup, each organization listed in organizations, and each additional
@@ -327,8 +324,30 @@ public class DashboardOmeMetadata extends DashboardMetadata {
         return platformName;
     }
 
+    /**
+     * @param platformName
+     *     the platform name to assign for this dataset
+     */
     public void setPlatformName(String platformName) {
         omeMData.setPlatformName(platformName);
+    }
+
+    /**
+     * @return the platform type for this dataset; never null but may be empty
+     */
+    public String getPlatformType() {
+        String platformType = omeMData.getPlatformType();
+        if ( platformType == null )
+            return "";
+        return platformType;
+    }
+
+    /**
+     * @param platformType
+     *     the platform type to assign for this dataset
+     */
+    public void setPlatformType(String platformType) {
+        omeMData.setPlatformType(platformType);
     }
 
     /**

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/shared/DatasetQCStatus.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/shared/DatasetQCStatus.java
@@ -115,6 +115,8 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
     public static final String FLAG_COMMENT = "H";
     // Flag recording the renaming of a dataset (to and from)
     public static final String FLAG_RENAMED = "R";
+    // Flag F no longer used - map to Suspend
+    private static final String FLAG_FAILED = "F";
 
     // Dataset status strings - datasets that can be modified
     private static final String STATUS_STRING_PRIVATE = "Private";
@@ -214,6 +216,8 @@ public class DatasetQCStatus implements Comparable<DatasetQCStatus>, Serializabl
         KEYSTRING_STATUS_MAP.put(Status.keyString(FLAG_CONFLICTED), Status.CONFLICTED);
         KEYSTRING_STATUS_MAP.put(Status.keyString(FLAG_RENAMED), Status.RENAMED);
         KEYSTRING_STATUS_MAP.put(Status.keyString(FLAG_COMMENT), Status.COMMENT);
+        // Add F flag for old QC in database, but map to Suspended
+        KEYSTRING_STATUS_MAP.put(Status.keyString(FLAG_FAILED), Status.SUSPENDED);
 
         KEYSTRING_STATUS_MAP.put(Status.keyString(STATUS_STRING_PRIVATE), Status.PRIVATE);
         KEYSTRING_STATUS_MAP.put(Status.keyString(STATUS_STRING_SUSPENDED), Status.SUSPENDED);


### PR DESCRIPTION
Enable programmatic fixing of platform types (which users provide) in the OME.xml file (e.g, Waveglider, Saildrone -> Autonomous Surface Vehicle; ferry, yacht -> Ship)

Do not overwrite the organization associated with a PI as they may move to another organization.  Only fill in if the organization is not given.

Handle the old F flag still present in the database, but map it to a QC status of Suspended.