### PR TITLE
Improved duplicate/overlap checking and reporting; minor fixes to client pages

### DIFF
--- a/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/ReportOverlaps.java
+++ b/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/ReportOverlaps.java
@@ -1,6 +1,7 @@
 package gov.noaa.pmel.dashboard.programs;
 
 import gov.noaa.pmel.dashboard.actions.OverlapChecker;
+import gov.noaa.pmel.dashboard.dsg.DsgNcFile;
 import gov.noaa.pmel.dashboard.handlers.DsgNcFileHandler;
 import gov.noaa.pmel.dashboard.server.DashboardConfigStore;
 import gov.noaa.pmel.dashboard.server.DashboardServerUtils;
@@ -36,7 +37,8 @@ public class ReportOverlaps {
             System.err.println("Checks for overlaps within and between datasets.  Overlaps are duplications of ");
             System.err.println("location and time values.  Extensive overlaps are very likely to be erroneous ");
             System.err.println("duplication of data, although there is the rare possibility of two instruments ");
-            System.err.println("on the same platform.  Data points with a WOCE-4 flag or missing fCO2_rec are ignored. ");
+            System.err.println("on the same platform.  Data points with a WOCE-4 flag or missing fCO2_rec are ");
+            System.err.println("ignored. ");
             System.err.println();
             System.err.println("ExpocodesFile");
             System.err.println("    a file of expocodes, one per line, specifying the datasets to examine ");
@@ -148,13 +150,13 @@ public class ReportOverlaps {
                     }
                     // Check that there is some overlap in time
                     double[] secondTimeMinMax = timeMinMaxMap.get(secondExpo);
-                    if ( (firstTimeMinMax[1] + OverlapChecker.MIN_TIME_DIFF < secondTimeMinMax[0]) ||
-                            (secondTimeMinMax[1] + OverlapChecker.MIN_TIME_DIFF < firstTimeMinMax[0]) )
+                    if ( (firstTimeMinMax[1] + DsgNcFile.MIN_TIME_DIFF < secondTimeMinMax[0]) ||
+                            (secondTimeMinMax[1] + DsgNcFile.MIN_TIME_DIFF < firstTimeMinMax[0]) )
                         continue;
                     // Check that there is some overlap in latitude
                     double[] secondLatMinMax = latMinMaxMap.get(secondExpo);
-                    if ( (firstLatMinMax[1] + OverlapChecker.MIN_LONLAT_DIFF < secondLatMinMax[0]) ||
-                            (secondLatMinMax[1] + OverlapChecker.MIN_LONLAT_DIFF < firstLatMinMax[0]) )
+                    if ( (firstLatMinMax[1] + DsgNcFile.MIN_LAT_DIFF < secondLatMinMax[0]) ||
+                            (secondLatMinMax[1] + DsgNcFile.MIN_LON_DIFF < firstLatMinMax[0]) )
                         continue;
                     checkExpos.add(secondExpo);
                 }

--- a/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/ReportOverlaps.java
+++ b/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/ReportOverlaps.java
@@ -27,16 +27,19 @@ public class ReportOverlaps {
 
     /**
      * @param args
-     *         ExpocodesFile - a file containing expocodes of the set
-     *         of datasets to examine for overlaps
+     *         ExpocodesFile - a file of expocodes specifying the datasets to examine for overlaps
      */
     public static void main(String[] args) {
         if ( args.length != 1 ) {
             System.err.println("Arguments:  ExpocodesFile");
             System.err.println();
+            System.err.println("Checks for overlaps within and between datasets.  Overlaps are duplications of ");
+            System.err.println("location and time values.  Extensive overlaps are very likely to be erroneous ");
+            System.err.println("duplication of data, although there is the rare possibility of two instruments ");
+            System.err.println("on the same platform. ");
+            System.err.println();
             System.err.println("ExpocodesFile");
-            System.err.println("    is a file containing expocodes, one per line, of the set ");
-            System.err.println("    of datasets to examine for overlaps. ");
+            System.err.println("    a file of expocodes, one per line, specifying the datasets to examine ");
             System.err.println();
             System.exit(1);
         }

--- a/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/ReportOverlaps.java
+++ b/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/ReportOverlaps.java
@@ -185,23 +185,31 @@ public class ReportOverlaps {
             else {
                 System.out.println("ExternalOverlap[ expocodes=[" + expos[0] + ", " + expos[1] + "],");
             }
-            ArrayList<Double> times = oerlap.getTimes();
-            System.out.println("    numRows=" + Integer.toString(times.size()) + ",");
             ArrayList<Integer>[] rowNums = oerlap.getRowNums();
+            ArrayList<Double>[] lons = oerlap.getLons();
+            ArrayList<Double>[] lats = oerlap.getLats();
+            ArrayList<Double>[] times = oerlap.getTimes();
+            System.out.println("    numRows=" + rowNums[0].size() + ",");
             System.out.println("    rowNums=[ " + rowNums[0].toString() + ",");
             System.out.println("              " + rowNums[1].toString() + " ],");
-            System.out.println("    lons=" + oerlap.getLons().toString());
-            System.out.println("    lats=" + oerlap.getLats().toString());
-            System.out.print("    times=[");
-            boolean first = true;
-            for (Double tval : times) {
-                if ( first )
-                    first = false;
-                else
+            System.out.println("    lons=[ " + lons[0].toString() + ",");
+            System.out.println("           " + lons[1].toString() + " ],");
+            System.out.println("    lats=[ " + lats[0].toString() + ",");
+            System.out.println("           " + lats[1].toString() + " ],");
+            System.out.print("    times=[[");
+            for (int k = 0; k < times[0].size(); k++) {
+                if ( k > 0 )
                     System.out.print(", ");
-                System.out.print(dateFmtr.format(new Date(Math.round(tval * 1000.0))));
+                System.out.print(dateFmtr.format(new Date(Math.round(times[0].get(k) * 1000.0))));
             }
-            System.out.println("]");
+            System.out.println("],");
+            System.out.print("           [");
+            for (int k = 0; k < times[1].size(); k++) {
+                if ( k > 0 )
+                    System.out.print(", ");
+                System.out.print(dateFmtr.format(new Date(Math.round(times[1].get(k) * 1000.0))));
+            }
+            System.out.println("]]");
             System.out.println("]");
         }
         System.exit(0);

--- a/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/ReportOverlaps.java
+++ b/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/ReportOverlaps.java
@@ -36,7 +36,7 @@ public class ReportOverlaps {
             System.err.println("Checks for overlaps within and between datasets.  Overlaps are duplications of ");
             System.err.println("location and time values.  Extensive overlaps are very likely to be erroneous ");
             System.err.println("duplication of data, although there is the rare possibility of two instruments ");
-            System.err.println("on the same platform. ");
+            System.err.println("on the same platform.  Data points with a WOCE-4 flag or missing fCO2_rec are ignored. ");
             System.err.println();
             System.err.println("ExpocodesFile");
             System.err.println("    a file of expocodes, one per line, specifying the datasets to examine ");

--- a/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/WoceDuplicates.java
+++ b/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/WoceDuplicates.java
@@ -28,9 +28,9 @@ public class WoceDuplicates {
      */
     public static void main(String[] args) {
         if ( args.length != 2 ) {
-            System.err.println("");
+            System.err.println();
             System.err.println("Arguments:  expocode  maxFCO2RecDiff");
-            System.err.println("");
+            System.err.println();
             System.err.println("Search for lon/lat/time/fCO2_rec duplicates within the dataset ");
             System.err.println("with the given expocode.  Any data points with a WOCE-4 flag or ");
             System.err.println("with fCO2_rec missing are ignored.  Any duplicates found are ");
@@ -41,11 +41,23 @@ public class WoceDuplicates {
             System.err.println("program may be run repeatedly for a number of different expocodes. ");
             System.err.println("The value maxFCO2RecDiff is the maximum allowed difference of ");
             System.err.println("fCO2_rec values in duplicates. ");
-            System.err.println("");
+            System.err.println();
             System.exit(1);
         }
-        String expocode = DashboardServerUtils.checkDatasetID(args[0]);
-        double maxFCO2RecDiff = Double.parseDouble(args[1]);
+        String expocode = null;
+        try {
+            expocode = DashboardServerUtils.checkDatasetID(args[0]);
+        } catch ( Exception ex ) {
+            System.err.println("Invalid expocode: " + ex.getMessage());
+            System.exit(1);
+        }
+        double maxFCO2RecDiff = 0.0;
+        try {
+            maxFCO2RecDiff = Double.parseDouble(args[1]);
+        } catch ( Exception ex ) {
+            System.err.println("Invalid maxFCO2RecDiff: " + ex.getMessage());
+            System.exit(1);
+        }
 
         // Get the default dashboard configuration
         DashboardConfigStore configStore = null;
@@ -53,9 +65,10 @@ public class WoceDuplicates {
             configStore = DashboardConfigStore.get(false);
         } catch ( Exception ex ) {
             System.err.println("Problems reading the default dashboard configuration file: " + ex.getMessage());
-            ex.printStackTrace();
             System.exit(1);
         }
+
+        boolean successful = true;
         try {
 
             try {
@@ -66,97 +79,116 @@ public class WoceDuplicates {
                 ArrayList<Overlap> oerlapList = oerlapChecker.getOverlaps(expocode,
                         Collections.singletonList(expocode), null, 0);
 
-                // If no overlaps found, then return an empty list
+                // If no overlaps found, nothing to do
                 if ( oerlapList.isEmpty() ) {
                     System.out.println(expocode + ": no overlaps found");
-                    DashboardConfigStore.shutdown();
-                    System.exit(0);
+                    System.err.println(expocode + ": no overlaps found");
                 }
+                else {
 
-                // Since checked against only one expocode, there should never be more than one Overlap object
-                if ( oerlapList.size() != 1 )
-                    throw new RuntimeException("unexpected error - more than one Overlap object returned " +
-                            "from OverlapChecker.getOverlaps when comparing a dataset with only itself");
-                Overlap oerlap = oerlapList.get(0);
+                    // Since checked against only one expocode, there should never be more than one Overlap object
+                    if ( oerlapList.size() != 1 )
+                        throw new RuntimeException("unexpected error - more than one Overlap object returned " +
+                                "from OverlapChecker.getOverlaps when comparing a dataset with only itself");
+                    Overlap oerlap = oerlapList.get(0);
 
-                // Get the version number from the DSG file
-                String versionStatus = dsgFileHandler.getDatasetQCFlagAndVersionStatus(expocode)[1];
-                // Remove the final 'U' or 'N' off the version-status
-                String version = versionStatus.substring(0, versionStatus.length() - 1);
+                    // Get the version number from the DSG file
+                    String versionStatus = dsgFileHandler.getDatasetQCFlagAndVersionStatus(expocode)[1];
+                    // Remove the final 'U' or 'N' off the version-status
+                    String version = versionStatus.substring(0, versionStatus.length() - 1);
 
-                // Get the lon/lat/time/fCO2_rec data values from the DSG file;
-                // any WOCE-4 data points has reset fCO2_rec to FP_MISSING_VALUE
-                double[][] dataVals = oerlapChecker.getMaskedLonLatTimeSstFco2Vals(expocode);
-                double[] lons = dataVals[0];
-                double[] lats = dataVals[1];
-                double[] times = dataVals[2];
-                double[] fco2s = dataVals[4];
+                    // Get the lon/lat/time/fCO2_rec data values from the DSG file;
+                    // any WOCE-4 data points has reset fCO2_rec to FP_MISSING_VALUE
+                    double[][] dataVals = oerlapChecker.getMaskedLonLatTimeSstFco2Vals(expocode);
+                    double[] lons = dataVals[0];
+                    double[] lats = dataVals[1];
+                    double[] times = dataVals[2];
+                    double[] fco2s = dataVals[4];
 
-                ArrayList<Integer>[] rowNums = oerlap.getRowNums();
-                int numPts = rowNums[0].size();
-                if ( (numPts < 1) || (rowNums[1].size() != numPts) )
-                    throw new RuntimeException("unexpected error - invalid number of overlapping data points");
-                ArrayList<DataLocation> dupDatInf = new ArrayList<DataLocation>(numPts);
-                for (int q = 0; q < numPts; q++) {
-                    int j = rowNums[0].get(q) - 1;
-                    int k = rowNums[1].get(q) - 1;
-                    if ( !DashboardUtils.closeTo(fco2s[j], fco2s[k], 0.0, maxFCO2RecDiff) )
-                        throw new IllegalArgumentException("overlap has too large of a difference in fCO2_rec ([" +
-                                j + "]: " + fco2s[j] + " vs [" + k + "]: " + fco2s[k] + ")");
-                    // WOCE-4 the latter of the two; if there are multiple duplications, only the first will be kept
-                    if ( k < j )
-                        k = j;
-                    DataLocation datinf = new DataLocation();
-                    datinf.setRowNumber(k + 1);
-                    datinf.setLongitude(lons[k]);
-                    datinf.setLatitude(lats[k]);
-                    datinf.setDataDate(new Date(Math.round(1000.0 * times[k])));
-                    datinf.setDataValue(fco2s[k]);
-                    dupDatInf.add(datinf);
-                }
-
-                // Assign the WOCE-4 flag for duplicates
-                DataQCEvent woceEvent = new DataQCEvent();
-                woceEvent.setDatasetId(expocode);
-                woceEvent.setVersion(version);
-                woceEvent.setFlagName(SocatTypes.WOCE_CO2_WATER.getVarName());
-                woceEvent.setFlagValue(DashboardServerUtils.WOCE_BAD);
-                woceEvent.setFlagDate(new Date());
-                woceEvent.setComment("duplicate lon/lat/time/fCO2_rec data points detected by automation");
-                woceEvent.setUsername(DashboardServerUtils.AUTOMATED_DATA_CHECKER_USERNAME);
-                woceEvent.setRealname(DashboardServerUtils.AUTOMATED_DATA_CHECKER_REALNAME);
-                woceEvent.setVarName(SocatTypes.FCO2_REC.getVarName());
-                woceEvent.setLocations(dupDatInf);
-
-                // Add the WOCE event to the database
-                configStore.getDatabaseRequestHandler().addDataQCEvent(Collections.singletonList(woceEvent));
-
-                // Assign the WOCE-4 flags in the full-data DSG file
-                ArrayList<DataLocation> unidentified = dsgFileHandler.updateDataQCFlags(woceEvent, false);
-                if ( !unidentified.isEmpty() ) {
-                    for (DataLocation loc : unidentified) {
-                        System.err.println(expocode + ": " + loc.toString());
+                    ArrayList<Integer>[] rowNums = oerlap.getRowNums();
+                    int numPts = rowNums[0].size();
+                    if ( (numPts < 1) || (rowNums[1].size() != numPts) )
+                        throw new RuntimeException("unexpected error - invalid number of overlapping data points");
+                    ArrayList<DataLocation> dupDatInf = new ArrayList<DataLocation>(numPts);
+                    int tooBig = 0;
+                    for (int q = 0; q < numPts; q++) {
+                        int j = rowNums[0].get(q) - 1;
+                        int k = rowNums[1].get(q) - 1;
+                        if ( DashboardUtils.closeTo(fco2s[j], fco2s[k], 0.0, maxFCO2RecDiff) ) {
+                            // WOCE-4 the latter of the two; if there are multiple duplications, only the first will be kept
+                            if ( k < j )
+                                k = j;
+                            DataLocation datinf = new DataLocation();
+                            datinf.setRowNumber(k + 1);
+                            datinf.setLongitude(lons[k]);
+                            datinf.setLatitude(lats[k]);
+                            datinf.setDataDate(new Date(Math.round(1000.0 * times[k])));
+                            datinf.setDataValue(fco2s[k]);
+                            dupDatInf.add(datinf);
+                        }
+                        else {
+                            System.err.println(expocode + ": overlap has too large of a difference in fCO2_rec - [" +
+                                    j + "]: " + fco2s[j] + " vs [" + k + "]: " + fco2s[k]);
+                            tooBig++;
+                        }
                     }
-                    throw new RuntimeException("unexpected error - unknown data location(s) ");
+                    if ( tooBig > 0 )
+                        System.out.println(expocode + ": " + tooBig +
+                                " overlaps have too large of a difference in fCO2_rec");
+
+                    // Assign the WOCE-4 flag for duplicates
+                    DataQCEvent woceEvent = new DataQCEvent();
+                    woceEvent.setDatasetId(expocode);
+                    woceEvent.setVersion(version);
+                    woceEvent.setFlagName(SocatTypes.WOCE_CO2_WATER.getVarName());
+                    woceEvent.setFlagValue(DashboardServerUtils.WOCE_BAD);
+                    woceEvent.setFlagDate(new Date());
+                    woceEvent.setComment("duplicate lon/lat/time/fCO2_rec data points detected by automation");
+                    woceEvent.setUsername(DashboardServerUtils.AUTOMATED_DATA_CHECKER_USERNAME);
+                    woceEvent.setRealname(DashboardServerUtils.AUTOMATED_DATA_CHECKER_REALNAME);
+                    woceEvent.setVarName(SocatTypes.FCO2_REC.getVarName());
+                    woceEvent.setLocations(dupDatInf);
+
+                    // Add the WOCE event to the database
+                    configStore.getDatabaseRequestHandler().addDataQCEvent(Collections.singletonList(woceEvent));
+
+                    // Assign the WOCE-4 flags in the full-data DSG file
+                    ArrayList<DataLocation> unidentified = dsgFileHandler.updateDataQCFlags(woceEvent, false);
+                    if ( !unidentified.isEmpty() ) {
+                        System.out.println(expocode + ": unexpected " +
+                                unidentified.size() + " unknown data locations");
+                        for (DataLocation loc : unidentified) {
+                            System.err.println(expocode + ": unexpected unknown data location " + loc.toString());
+                        }
+                        dupDatInf.removeAll(unidentified);
+                        successful = false;
+                    }
+
+                    // Re-create the decimated-data DSG file
+                    dsgFileHandler.decimateDatasetDsg(expocode);
+
+                    if ( !dupDatInf.isEmpty() )
+                        System.out.println(expocode + ": WOCE-4 applied to " +
+                                dupDatInf.size() + " duplicate data locations");
+                    for (DataLocation loc : dupDatInf) {
+                        System.err.println(expocode + ": WOCE-4 applied to duplicate data location " + loc.toString());
+                    }
                 }
 
-                // Re-create the decimated-data DSG file
-                dsgFileHandler.decimateDatasetDsg(expocode);
-
-                for (DataLocation loc : dupDatInf) {
-                    System.out.println(expocode +
-                            ": WOCE-4 applied to lon/lat/time/fCO2_rec duplicate data point " + loc.toString());
-                }
             } catch ( Exception ex ) {
-                System.err.println(expocode + ": " + ex.getMessage());
+                System.out.println(expocode + ": " + ex.getMessage());
                 ex.printStackTrace();
-                System.exit(1);
+                successful = false;
             }
 
         } finally {
             DashboardConfigStore.shutdown();
         }
+
+        if ( !successful )
+            System.exit(1);
         System.exit(0);
     }
 
 }
+

--- a/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/WoceDuplicates.java
+++ b/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/WoceDuplicates.java
@@ -113,7 +113,14 @@ public class WoceDuplicates {
                     int tooBig = 0;
                     for (int q = 0; q < numPts; q++) {
                         int j = rowNums[0].get(q) - 1;
+                        // Ignore if either data point is already (or will be) WOCE-4 or is missing fCO2_rec
+                        if ( DashboardUtils.closeTo(fco2s[j], DashboardUtils.FP_MISSING_VALUE,
+                                DashboardUtils.MAX_RELATIVE_ERROR, DashboardUtils.MAX_ABSOLUTE_ERROR) )
+                            continue;
                         int k = rowNums[1].get(q) - 1;
+                        if ( DashboardUtils.closeTo(fco2s[k], DashboardUtils.FP_MISSING_VALUE,
+                                DashboardUtils.MAX_RELATIVE_ERROR, DashboardUtils.MAX_ABSOLUTE_ERROR) )
+                            continue;
                         if ( DashboardUtils.closeTo(fco2s[j], fco2s[k], 0.0, maxFCO2RecDiff) ) {
                             // WOCE-4 the latter of the two; if there are multiple duplications, only the first will be kept
                             if ( k < j )
@@ -125,6 +132,8 @@ public class WoceDuplicates {
                             datinf.setDataDate(new Date(Math.round(1000.0 * times[k])));
                             datinf.setDataValue(fco2s[k]);
                             dupDatInf.add(datinf);
+                            // This data point will be WOCE-4 so mark it as such in case it is in other duplicate pairs
+                            fco2s[k] = DashboardUtils.FP_MISSING_VALUE;
                         }
                         else {
                             System.err.println(expocode + ": overlap has too large of a difference in fCO2_rec - [" +

--- a/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/WoceDuplicates.java
+++ b/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/WoceDuplicates.java
@@ -38,12 +38,13 @@ public class WoceDuplicates {
             System.err.println("Arguments: expocode");
             System.err.println("");
             System.err.println("Search for lon/lat/time/fCO2_rec duplicates within the dataset ");
-            System.err.println("with the given expocode.  Any duplicates found are assigned a ");
-            System.err.println("WOCE-4 flag by the automated data checker with an appropriate ");
-            System.err.println("message.  If duplicates are found, the database and full-data DSG");
-            System.err.println("file are updated and the decimated-data DSG file is regenerated. ");
-            System.err.println("ERDDAP is NOT notified of any changes since this program may ");
-            System.err.println("be run repeatedly for a number of different expocodes. ");
+            System.err.println("with the given expocode.  Any data points with a WOCE-4 flag or ");
+            System.err.println("with fCO2_rec missing are ignored.  Any duplicates found are ");
+            System.err.println("assigned a WOCE-4 flag by the automated data checker with an ");
+            System.err.println("appropriate message.  If duplicates are found, the database and ");
+            System.err.println("full-data DSG file are updated and the decimated-data DSG file is ");
+            System.err.println("regenerated.  ERDDAP is NOT notified of any changes since this ");
+            System.err.println("program may be run repeatedly for a number of different expocodes. ");
             System.err.println("");
             System.exit(1);
         }

--- a/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/WoceDuplicates.java
+++ b/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/WoceDuplicates.java
@@ -152,7 +152,7 @@ public class WoceDuplicates {
                     // Add the WOCE event to the database
                     configStore.getDatabaseRequestHandler().addDataQCEvent(Collections.singletonList(woceEvent));
 
-                    // Assign the WOCE-4 flags in the full-data DSG file
+                    // Assign the WOCE-4 flags in the full-data DSG file, and then regenerate the decimated dataset
                     ArrayList<DataLocation> unidentified = dsgFileHandler.updateDataQCFlags(woceEvent, false);
                     if ( !unidentified.isEmpty() ) {
                         System.out.println(expocode + ": unexpected " +
@@ -163,9 +163,6 @@ public class WoceDuplicates {
                         dupDatInf.removeAll(unidentified);
                         successful = false;
                     }
-
-                    // Re-create the decimated-data DSG file
-                    dsgFileHandler.decimateDatasetDsg(expocode);
 
                     if ( !dupDatInf.isEmpty() )
                         System.out.println(expocode + ": WOCE-4 applied to " +

--- a/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/WoceOverlapTail.java
+++ b/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/WoceOverlapTail.java
@@ -23,7 +23,7 @@ public class WoceOverlapTail {
 
     /**
      * @param args
-     *         firstExpo  secondExpo
+     *         firstExpo  secondExpo  maxFCO2RecDiff
      *         <p>
      *         Computes the overlaps between the two datasets indicated by the expocodes.
      *         If the overlap is one where the tail of one is a duplicate of the start of
@@ -42,135 +42,150 @@ public class WoceOverlapTail {
             System.err.println();
             System.exit(1);
         }
-        String firstExpo = DashboardServerUtils.checkDatasetID(args[0]);
-        String secondExpo = DashboardServerUtils.checkDatasetID(args[1]);
-        double maxFCO2RecDiff = Double.parseDouble(args[2]);
+        String firstExpo = null;
+        String secondExpo = null;
+        try {
+            firstExpo = DashboardServerUtils.checkDatasetID(args[0]);
+            secondExpo = DashboardServerUtils.checkDatasetID(args[1]);
+        } catch ( Exception ex ) {
+            System.err.println("Invalid  expocode: " + ex.getMessage());
+            System.exit(1);
+        }
+        double maxFCO2RecDiff = 0.0;
+        try {
+            maxFCO2RecDiff = Double.parseDouble(args[2]);
+        } catch ( Exception ex ) {
+            System.err.println("Invalid fCO2RecMax: " + ex.getMessage());
+            System.exit(1);
+        }
 
         DashboardConfigStore configStore = null;
         try {
             configStore = DashboardConfigStore.get(false);
         } catch ( Exception ex ) {
             System.err.println("Problems obtaining the default dashboard configuration: " + ex.getMessage());
-            ex.printStackTrace();
             System.exit(1);
         }
+
+        boolean successful = true;
         try {
-
-            DsgNcFileHandler dsgHandler = configStore.getDsgNcFileHandler();
-            OverlapChecker oerlapChecker = new OverlapChecker(dsgHandler);
-
-            Overlap oerlap = null;
             try {
+
+                DsgNcFileHandler dsgHandler = configStore.getDsgNcFileHandler();
+                OverlapChecker oerlapChecker = new OverlapChecker(dsgHandler);
+
                 ArrayList<Overlap> overlapList = oerlapChecker.getOverlaps(firstExpo,
                         Collections.singletonList(secondExpo), null, 0);
-                if ( overlapList == null )
-                    throw new IllegalArgumentException("no overlap found");
-                if ( overlapList.size() != 1 )
-                    throw new RuntimeException("unexpected overlap list size of " + overlapList.size());
-                oerlap = overlapList.get(0);
-            } catch ( Exception ex ) {
-                System.err.println("Problems getting the overlap between " + firstExpo +
-                        " and " + secondExpo + ": " + ex.getMessage());
-                ex.printStackTrace();
-                System.exit(1);
-            }
+                if ( overlapList == null ) {
+                    System.out.println(firstExpo + " " + secondExpo + ": no overlaps found");
+                    System.err.println(firstExpo + " " + secondExpo + ": no overlaps found");
+                }
+                else {
 
-            ArrayList<Integer> firstRowNums = oerlap.getRowNums()[0];
-            double[] firstFCO2 = null;
-            try {
-                ArrayList<Integer> secondRowNums = oerlap.getRowNums()[1];
-                // Verify the overlap row numbers are appropriate for performing this automatic WOCE flagging
-                if ( firstRowNums.size() != secondRowNums.size() )
-                    throw new RuntimeException("unexpected different number of data row numbers");
-                int delta = firstRowNums.get(0) - secondRowNums.get(0);
-                String[] expocodes = oerlap.getDatasetIds();
-                if ( (firstExpo.equals(expocodes[0]) && (delta < 0)) ||
-                        (firstExpo.equals(expocodes[1]) && (delta > 0)) )
-                    throw new IllegalArgumentException(
-                            "delta in row numbers between datasets is negative (switch order of datasets)");
-                for (int k = 1; k < firstRowNums.size(); k++) {
-                    if ( firstRowNums.get(k) != secondRowNums.get(k) + delta )
-                        throw new IllegalArgumentException("inconsistent delta in row numbers between datasets");
-                }
-                // Verify the fCO2_rec values are the same in the overlap
-                firstFCO2 = dsgHandler.readDoubleVarDataValues(firstExpo, SocatTypes.FCO2_REC.getVarName());
-                ArrayList<Double> firstOverlapFCO2 = new ArrayList<Double>(firstRowNums.size());
-                for (Integer num : firstRowNums) {
-                    firstOverlapFCO2.add(firstFCO2[num - 1]);
-                }
-                double[] secondFCO2 = dsgHandler.readDoubleVarDataValues(secondExpo, SocatTypes.FCO2_REC.getVarName());
-                ArrayList<Double> secondOverlapFCO2 = new ArrayList<Double>(secondRowNums.size());
-                for (Integer num : secondRowNums) {
-                    secondOverlapFCO2.add(secondFCO2[num - 1]);
-                }
-                for (int k = 0; k < firstOverlapFCO2.size(); k++) {
-                    if ( !DashboardUtils.closeTo(firstOverlapFCO2.get(k), secondOverlapFCO2.get(k),
-                            0.0, maxFCO2RecDiff) ) {
-                        System.err.println(" fCO2_rec: " + firstOverlapFCO2.toString());
-                        System.err.println("           " + secondOverlapFCO2.toString());
-                        throw new IllegalArgumentException("overlap fCO2_rec " + firstOverlapFCO2.get(k).toString() +
-                                " versus " + secondOverlapFCO2.get(k).toString());
+                    if ( overlapList.size() != 1 )
+                        throw new RuntimeException("unexpected overlap list size of " + overlapList.size());
+                    Overlap oerlap = overlapList.get(0);
+                    ArrayList<Integer>[] rowNums = oerlap.getRowNums();
+                    int numOverlap = rowNums[0].size();
+                    if ( rowNums[1].size() != numOverlap )
+                        throw new RuntimeException("unexpected different number of data row numbers");
+
+                    // Verify the overlap row numbers are appropriate for performing this automatic WOCE flagging
+                    int delta = rowNums[0].get(0) - rowNums[1].get(0);
+                    String[] expocodes = oerlap.getDatasetIds();
+                    if ( (firstExpo.equals(expocodes[0]) && (delta < 0)) ||
+                            (firstExpo.equals(expocodes[1]) && (delta > 0)) )
+                        throw new IllegalArgumentException(
+                                "negative delta in overlap row numbers between datasets (switch order of datasets?)");
+                    for (int k = 1; k < numOverlap; k++) {
+                        if ( rowNums[0].get(k) != rowNums[1].get(k) + delta )
+                            throw new IllegalArgumentException(
+                                    "inconsistent delta in overlap row numbers between datasets");
                     }
-                }
-            } catch ( Exception ex ) {
-                System.err.println("Invalid overlap between " + firstExpo +
-                        " and " + secondExpo + ": " + ex.getMessage());
-                ex.printStackTrace();
-                System.exit(1);
-            }
 
-            // Add the WOCE flags to the tail of the first dataset
-            try {
-                // Create the WOCE event
-                double[][] datavals = dsgHandler.readLonLatTimeDataValues(firstExpo);
-                double[] longitudes = datavals[0];
-                double[] latitudes = datavals[1];
-                double[] times = datavals[2];
-                ArrayList<DataLocation> locations = new ArrayList<DataLocation>(firstRowNums.size());
-                for (Integer num : firstRowNums) {
-                    int k = num - 1;
-                    DataLocation loc = new DataLocation();
-                    loc.setDataDate(new Date(Math.round(times[k] * 1000.0)));
-                    loc.setDataValue(firstFCO2[k]);
-                    loc.setLatitude(latitudes[k]);
-                    loc.setLongitude(longitudes[k]);
-                    loc.setRowNumber(num);
-                    locations.add(loc);
-                }
-                DataQCEvent woceEvent = new DataQCEvent();
-                woceEvent.setDatasetId(firstExpo);
-                woceEvent.setVersion(configStore.getQCVersion());
-                woceEvent.setFlagName(SocatTypes.WOCE_CO2_WATER.getVarName());
-                woceEvent.setFlagValue(DashboardServerUtils.WOCE_BAD);
-                woceEvent.setFlagDate(new Date());
-                woceEvent.setComment("duplicate lon/lat/time/fCO2_rec data points with " +
-                        secondExpo + " detected by automation");
-                woceEvent.setUsername(DashboardServerUtils.AUTOMATED_DATA_CHECKER_USERNAME);
-                woceEvent.setRealname(DashboardServerUtils.AUTOMATED_DATA_CHECKER_REALNAME);
-                woceEvent.setVarName(SocatTypes.FCO2_REC.getVarName());
-                woceEvent.setLocations(locations);
+                    double[][] firstDataVals = oerlapChecker.getMaskedLonLatTimeSstFco2Vals(firstExpo);
+                    double[] firstLons = firstDataVals[0];
+                    double[] firstLats = firstDataVals[1];
+                    double[] firstTimes = firstDataVals[2];
+                    double[] firstFCO2s = firstDataVals[4];
 
-                // Add the WOCE event to the database
-                configStore.getDatabaseRequestHandler().addDataQCEvent(Collections.singletonList(woceEvent));
-                // Assign the WOCE-4 flags in the full-data DSG file, then regenerate the decimated dataset
-                ArrayList<DataLocation> unidentified = dsgHandler.updateDataQCFlags(woceEvent, false);
-                if ( !unidentified.isEmpty() ) {
-                    for (DataLocation loc : unidentified) {
-                        System.err.println("unknown data location: " + loc.toString());
+                    double[][] secondDataVals = oerlapChecker.getMaskedLonLatTimeSstFco2Vals(secondExpo);
+                    double[] secondFCO2s = secondDataVals[4];
+
+                    // Verify the fCO2_rec values in the overlap are the acceptably close to each other
+                    for (int q = 0; q < numOverlap; q++) {
+                        int j = rowNums[0].get(q) - 1;
+                        double firstFCO2 = firstFCO2s[j];
+                        int k = rowNums[1].get(q) - 1;
+                        double secondFCO2 = secondFCO2s[k];
+                        if ( !DashboardUtils.closeTo(firstFCO2, secondFCO2, 0.0, maxFCO2RecDiff) ) {
+                            throw new IllegalArgumentException("overlap has too large of a difference in fCO2_rec - [" +
+                                    j + "]: " + firstFCO2 + "  vs " + "[" + k + "]: " + secondFCO2);
+                        }
                     }
-                    throw new RuntimeException("unexpected error");
+
+                    // Add the WOCE flags to the tail of the first dataset
+                    ArrayList<DataLocation> locations = new ArrayList<DataLocation>(numOverlap);
+                    for (int num : rowNums[0]) {
+                        int k = num - 1;
+                        DataLocation loc = new DataLocation();
+                        loc.setDataDate(new Date(Math.round(firstTimes[k] * 1000.0)));
+                        loc.setDataValue(firstFCO2s[k]);
+                        loc.setLatitude(firstLats[k]);
+                        loc.setLongitude(firstLons[k]);
+                        loc.setRowNumber(num);
+                        locations.add(loc);
+                    }
+                    DataQCEvent woceEvent = new DataQCEvent();
+                    woceEvent.setDatasetId(firstExpo);
+                    woceEvent.setVersion(configStore.getQCVersion());
+                    woceEvent.setFlagName(SocatTypes.WOCE_CO2_WATER.getVarName());
+                    woceEvent.setFlagValue(DashboardServerUtils.WOCE_BAD);
+                    woceEvent.setFlagDate(new Date());
+                    woceEvent.setComment("duplicate lon/lat/time/fCO2_rec data points with " +
+                            secondExpo + " detected by automation");
+                    woceEvent.setUsername(DashboardServerUtils.AUTOMATED_DATA_CHECKER_USERNAME);
+                    woceEvent.setRealname(DashboardServerUtils.AUTOMATED_DATA_CHECKER_REALNAME);
+                    woceEvent.setVarName(SocatTypes.FCO2_REC.getVarName());
+                    woceEvent.setLocations(locations);
+
+                    // Add the WOCE event to the database
+                    configStore.getDatabaseRequestHandler().addDataQCEvent(Collections.singletonList(woceEvent));
+
+                    // Assign the WOCE-4 flags in the full-data DSG file, then regenerate the decimated dataset
+                    ArrayList<DataLocation> unidentified = dsgHandler.updateDataQCFlags(woceEvent, false);
+                    if ( !unidentified.isEmpty() ) {
+                        System.out.println(firstExpo + ": unexpected " +
+                                unidentified.size() + " unknown data locations");
+                        for (DataLocation loc : unidentified) {
+                            System.err.println(firstExpo + ": unexpected unknown data location " + loc.toString());
+                        }
+                        locations.removeAll(unidentified);
+                        successful = false;
+                    }
+
+                    // Re-create the decimated-data DSG file
+                    dsgHandler.decimateDatasetDsg(firstExpo);
+
+                    if ( !locations.isEmpty() )
+                        System.out.println(firstExpo + ": WOCE-4 applied to " +
+                                locations.size() + " duplicate data locations");
+                    for (DataLocation loc : locations) {
+                        System.err.println(firstExpo + ": WOCE-4 applied to duplicate data location " + loc.toString());
+                    }
+
                 }
-                // Report WOCE-4 of duplicates
-                System.out.println("WOCE-4 assigned to duplicate datapoints in " +
-                        firstExpo + ": " + firstRowNums.toString());
+
             } catch ( Exception ex ) {
-                System.err.println("Problems assigning WOCE flags to " + firstExpo + ": " + ex.getMessage());
-                ex.printStackTrace();
+                System.err.println(firstExpo + " " + secondExpo + ": " + ex.getMessage());
+                successful = false;
             }
         } finally {
             DashboardConfigStore.shutdown();
         }
 
+        if ( !successful )
+            System.exit(1);
         System.exit(0);
     }
 

--- a/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/WoceOverlapTail.java
+++ b/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/WoceOverlapTail.java
@@ -152,7 +152,7 @@ public class WoceOverlapTail {
                     // Add the WOCE event to the database
                     configStore.getDatabaseRequestHandler().addDataQCEvent(Collections.singletonList(woceEvent));
 
-                    // Assign the WOCE-4 flags in the full-data DSG file, then regenerate the decimated dataset
+                    // Assign the WOCE-4 flags in the full-data DSG file, and then regenerate the decimated dataset
                     ArrayList<DataLocation> unidentified = dsgHandler.updateDataQCFlags(woceEvent, false);
                     if ( !unidentified.isEmpty() ) {
                         System.out.println(firstExpo + ": unexpected " +
@@ -163,9 +163,6 @@ public class WoceOverlapTail {
                         locations.removeAll(unidentified);
                         successful = false;
                     }
-
-                    // Re-create the decimated-data DSG file
-                    dsgHandler.decimateDatasetDsg(firstExpo);
 
                     if ( !locations.isEmpty() )
                         System.out.println(firstExpo + ": WOCE-4 applied to " +

--- a/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/WoceOverlapTail.java
+++ b/DashboardApps/src/main/java/gov/noaa/pmel/dashboard/programs/WoceOverlapTail.java
@@ -15,6 +15,7 @@ import gov.noaa.pmel.dashboard.shared.Overlap;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 
 /**
@@ -67,14 +68,12 @@ public class WoceOverlapTail {
 
             Overlap oerlap = null;
             try {
-                ArrayList<String> others = new ArrayList<String>(1);
-                others.add(secondExpo);
-                ArrayList<Overlap> overlapList = oerlapChecker.getOverlaps(firstExpo, others, null, 0);
+                ArrayList<Overlap> overlapList = oerlapChecker.getOverlaps(firstExpo,
+                        Collections.singletonList(secondExpo), null, 0);
                 if ( overlapList == null )
                     throw new IllegalArgumentException("no overlap found");
                 if ( overlapList.size() != 1 )
-                    throw new RuntimeException("unexpected overlap list size of " +
-                            Integer.toString(overlapList.size()));
+                    throw new RuntimeException("unexpected overlap list size of " + overlapList.size());
                 oerlap = overlapList.get(0);
             } catch ( Exception ex ) {
                 System.err.println("Problems getting the overlap between " + firstExpo +
@@ -111,8 +110,8 @@ public class WoceOverlapTail {
                     secondOverlapFCO2.add(secondFCO2[num - 1]);
                 }
                 for (int k = 0; k < firstOverlapFCO2.size(); k++) {
-                    if ( !DashboardUtils.closeTo(firstOverlapFCO2.get(k), secondOverlapFCO2.get(k), 0.0,
-                            MIN_FCO2_DIFF) ) {
+                    if ( !DashboardUtils.closeTo(firstOverlapFCO2.get(k), secondOverlapFCO2.get(k),
+                            0.0, MIN_FCO2_DIFF) ) {
                         System.err.println(" fCO2_rec: " + firstOverlapFCO2.toString());
                         System.err.println("           " + secondOverlapFCO2.toString());
                         throw new IllegalArgumentException("overlap fCO2_rec " + firstOverlapFCO2.get(k).toString() +

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/actions/DatasetModifier.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/actions/DatasetModifier.java
@@ -1,35 +1,20 @@
-/**
- *
- */
 package gov.noaa.pmel.dashboard.actions;
 
-import gov.noaa.pmel.dashboard.datatype.SocatTypes;
-import gov.noaa.pmel.dashboard.dsg.DsgMetadata;
-import gov.noaa.pmel.dashboard.dsg.DsgNcFile;
-import gov.noaa.pmel.dashboard.dsg.StdDataArray;
 import gov.noaa.pmel.dashboard.handlers.CheckerMessageHandler;
 import gov.noaa.pmel.dashboard.handlers.DataFileHandler;
 import gov.noaa.pmel.dashboard.handlers.DatabaseRequestHandler;
 import gov.noaa.pmel.dashboard.handlers.DsgNcFileHandler;
 import gov.noaa.pmel.dashboard.handlers.MetadataFileHandler;
 import gov.noaa.pmel.dashboard.handlers.UserFileHandler;
-import gov.noaa.pmel.dashboard.qc.DataLocation;
-import gov.noaa.pmel.dashboard.qc.DataQCEvent;
 import gov.noaa.pmel.dashboard.server.DashboardConfigStore;
 import gov.noaa.pmel.dashboard.server.DashboardServerUtils;
 import gov.noaa.pmel.dashboard.shared.DashboardDataset;
 import gov.noaa.pmel.dashboard.shared.DashboardDatasetList;
 import gov.noaa.pmel.dashboard.shared.DashboardMetadata;
-import gov.noaa.pmel.dashboard.shared.DashboardUtils;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.TimeZone;
-import java.util.TreeSet;
 
 /**
  * Methods for revising dataset information, such as dataset owner or dataset ID.
@@ -37,12 +22,6 @@ import java.util.TreeSet;
  * @author Karl Smith
  */
 public class DatasetModifier {
-
-    private static final SimpleDateFormat DATETIMESTAMPER = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-
-    static {
-        DATETIMESTAMPER.setTimeZone(TimeZone.getTimeZone("UTC"));
-    }
 
     DashboardConfigStore configStore;
 
@@ -151,141 +130,6 @@ public class DatasetModifier {
         dbHandler.renameQCFlags(oldStdId, newStdId, version, username);
         // also rename the WOCE_flags.tsv file, if it exists
         metaHandler.renameWoceFlagMsgsFile(oldStdId, newStdId, dbHandler);
-    }
-
-    /**
-     * Applies WOCE-4 flags to any duplicated lon/lat/depth/time/fCO2_rec data points found within a data set.
-     * Data points with a WOCE-4 flag or missing fCO2_rec are ignored.
-     * Add the WOCE event to the database, modifies the full-data DSG file, and recreates the decimated-data DSG file.
-     * Does not flag ERDDAP as this may be called repeatedly with different expocodes.
-     *
-     * @param expocode
-     *         examine the data of the dataset with this ID
-     *
-     * @return list of duplicate lon/lat/depth/time/fCO2_rec data points given a WOCE-4 flag
-     *
-     * @throws IllegalArgumentException
-     *         if the dataset ID is invalid, or if unable to regenerate the decimated DSG file
-     * @throws IOException
-     *         if unable to read or update the full-data DSG file, or if unable to read or update the database
-     */
-    public ArrayList<DataLocation> woceDuplicateDatapoints(String expocode)
-            throws IllegalArgumentException, IOException {
-        String upperExpo = DashboardServerUtils.checkDatasetID(expocode);
-
-        // Get the metadata and data from the DSG file
-        DsgNcFileHandler dsgFileHandler = configStore.getDsgNcFileHandler();
-        DsgNcFile dsgFile = dsgFileHandler.getDsgNcFile(upperExpo);
-        ArrayList<String> unknownVars = dsgFile.readMetadata(configStore.getKnownMetadataTypes());
-        if ( unknownVars.size() > 0 ) {
-            String msg = "Unassigned metadata variables: ";
-            for (String var : unknownVars) {
-                msg += var + "; ";
-            }
-            System.err.println(msg);
-        }
-        unknownVars = dsgFile.readData(configStore.getKnownDataFileTypes());
-        if ( unknownVars.size() > 0 ) {
-            String msg = "Unassigned data variables: ";
-            for (String var : unknownVars) {
-                msg += var + "; ";
-            }
-            System.err.println(msg);
-        }
-
-        DsgMetadata socatMeta = dsgFile.getMetadata();
-        StdDataArray dataArray = dsgFile.getStdDataArray();
-
-        String versionStatus = socatMeta.getVersion();
-        // Remove the final 'U' or 'N' off the version-status saved in the DsgMetadata
-        String version = versionStatus.substring(0, versionStatus.length() - 1);
-
-        Integer lonIdx = dataArray.getIndexOfType(DashboardServerUtils.LONGITUDE);
-        if ( lonIdx == null )
-            throw new IllegalArgumentException("Full-data DSG file does not have longitudes");
-        Integer latIdx = dataArray.getIndexOfType(DashboardServerUtils.LATITUDE);
-        if ( latIdx == null )
-            throw new IllegalArgumentException("Full-data DSG file does not have latitudes");
-        Integer depthIdx = dataArray.getIndexOfType(DashboardServerUtils.SAMPLE_DEPTH);
-        if ( depthIdx == null )
-            throw new IllegalArgumentException("Full-data DSG file does not have depths");
-        Integer timeIdx = dataArray.getIndexOfType(DashboardServerUtils.TIME);
-        if ( timeIdx == null )
-            throw new IllegalArgumentException("Full-data DSG file does not have fully-specified times");
-        Integer fco2RecIdx = dataArray.getIndexOfType(SocatTypes.FCO2_REC);
-        if ( fco2RecIdx == null )
-            throw new IllegalArgumentException("Full-data DSG file does not have " +
-                    SocatTypes.FCO2_REC.getVarName() + " values");
-        Integer woceWaterIdx = dataArray.getIndexOfType(SocatTypes.WOCE_CO2_WATER);
-        if ( woceWaterIdx == null )
-            throw new IllegalArgumentException("Full-data DSG file does not have " +
-                    SocatTypes.WOCE_CO2_WATER.getVarName() + " values");
-
-        // Create the set for holding previous lon/lat/depth/time/fCO2_rec data
-        TreeSet<DataLocation> prevDatInf = new TreeSet<DataLocation>(DataLocation.IGNORE_ROW_NUM_COMPARATOR);
-        // Create a list for holding any duplicate lon/lat/depth/time/fCO2_rec data
-        ArrayList<DataLocation> dupDatInf = new ArrayList<DataLocation>();
-        // Generate a set of lon/lat/depth/time/fCO2_rec data points,
-        // recording where duplicates are found
-        for (int j = 0; j < dataArray.getNumSamples(); j++) {
-            // Ignore data points with missing fCO2_rec
-            Double fco2Rec = (Double) dataArray.getStdVal(j, fco2RecIdx);
-            if ( DashboardUtils.closeTo(fco2Rec, DashboardUtils.FP_MISSING_VALUE,
-                    DashboardUtils.MAX_RELATIVE_ERROR, DashboardUtils.MAX_ABSOLUTE_ERROR) )
-                continue;
-            // Only consider WOCE-2 and WOCE-3 data points (ignore those already WOCE-4)
-            String woceFlag = (String) dataArray.getStdVal(j, woceWaterIdx);
-            if ( DashboardServerUtils.WOCE_ACCEPTABLE.equals(woceFlag) ||
-                    DashboardServerUtils.WOCE_QUESTIONABLE.equals(woceFlag) ) {
-                DataLocation datinf = new DataLocation();
-                datinf.setRowNumber(j);
-                datinf.setLongitude((Double) dataArray.getStdVal(j, lonIdx));
-                datinf.setLatitude((Double) dataArray.getStdVal(j, latIdx));
-                datinf.setDepth((Double) dataArray.getStdVal(j, depthIdx));
-                datinf.setDataDate(new Date(Math.round(1000.0 * (Double) dataArray.getStdVal(j, timeIdx))));
-                datinf.setDataValue(fco2Rec);
-                if ( !prevDatInf.add(datinf) ) {
-                    dupDatInf.add(datinf);
-                }
-            }
-        }
-
-        if ( !dupDatInf.isEmpty() ) {
-            // Assign the WOCE-4 flag for duplicates
-            DataQCEvent woceEvent = new DataQCEvent();
-            woceEvent.setDatasetId(upperExpo);
-            woceEvent.setVersion(version);
-            woceEvent.setFlagName(SocatTypes.WOCE_CO2_WATER.getVarName());
-            woceEvent.setFlagValue(DashboardServerUtils.WOCE_BAD);
-            woceEvent.setFlagDate(new Date());
-            woceEvent.setComment("duplicate lon/lat/depth/time/fCO2_rec data points detected by automation");
-            woceEvent.setUsername(DashboardServerUtils.AUTOMATED_DATA_CHECKER_USERNAME);
-            woceEvent.setRealname(DashboardServerUtils.AUTOMATED_DATA_CHECKER_REALNAME);
-            woceEvent.setVarName(SocatTypes.FCO2_REC.getVarName());
-            woceEvent.setLocations(dupDatInf);
-            // Add the WOCE event to the database
-            try {
-                configStore.getDatabaseRequestHandler().addDataQCEvent(Arrays.asList(woceEvent));
-            } catch ( SQLException ex ) {
-                throw new IOException("Problem assigning WOCE-4 flags in database: " + ex.getMessage());
-            }
-            // Assign the WOCE-4 flags in the full-data DSG file
-            ArrayList<DataLocation> unidentified = dsgFile.updateDataQCFlags(woceEvent, false);
-            if ( !unidentified.isEmpty() ) {
-                for (DataLocation loc : unidentified) {
-                    System.err.println("unexpected unknown data location: " + loc.toString());
-                }
-                throw new IOException("Problem assigning WOCE-4 flags in the full-data DSG file");
-            }
-            // Re-create the decimated-data DSG file
-            try {
-                dsgFileHandler.decimateDatasetDsg(upperExpo);
-            } catch ( Exception ex ) {
-                throw new IOException("Unable to decimate the updated full-data DSG file: " + ex.getMessage());
-            }
-        }
-
-        return dupDatInf;
     }
 
 }

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/actions/OverlapChecker.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/actions/OverlapChecker.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package gov.noaa.pmel.dashboard.actions;
 
 import gov.noaa.pmel.dashboard.datatype.SocatTypes;
@@ -25,12 +22,13 @@ public class OverlapChecker {
 
     /**
      * Minimum time difference, in seconds, for two values to be considered different
+     * Duplicate times in some datases were "fixed" by using fractional seconds, so go to milliseconds.
      */
-    public static final double MIN_TIME_DIFF = 1.0;
+    public static final double MIN_TIME_DIFF = 0.001;
     /**
      * Minimum longitude or latitude difference, in degrees, for two value to be considered different
      */
-    public static final double MIN_LONLAT_DIFF = 0.001;
+    public static final double MIN_LONLAT_DIFF = 0.0001;
     /**
      * Cutoff time window, in seconds, for still considering data points - to allow some time disorder
      */

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/actions/OverlapChecker.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/actions/OverlapChecker.java
@@ -127,7 +127,7 @@ public class OverlapChecker {
 
             // Check for an overlap
             Overlap oerlap = checkForOverlaps(upperExpos, lons, lats, times, ignores);
-            if ( oerlap != null ) {
+            if ( !oerlap.isEmpty() ) {
                 overlapList.add(oerlap);
                 if ( progressPrinter != null ) {
                     double checkDeltaSecs = (System.currentTimeMillis() - checkStartMilliTime) / 1000.0;
@@ -194,15 +194,15 @@ public class OverlapChecker {
      * @param ignore
      *         if true for a data point, any overlaps with that data point is ignored
      *
-     * @return the overlap found between the two datasets, or null if no overlaps were found
+     * @return the overlap found between the two datasets; never null but may be empty.
      *
      * @throws IllegalArgumentException
-     *         if any of the arguments or argument array values is null, if any of the arguments is not an array of two
-     *         objects, or if there is not the same number of longitudes, latitudes, and times for a dataset
+     *         if any of the arguments or argument array values is null,
+     *         if any of the arguments is not an array of two objects, or
+     *         if there is not the same number of longitudes, latitudes, and times for a dataset
      */
     private Overlap checkForOverlaps(String[] expocodes, double[][] longitudes,
-            double[][] latitudes, double[][] times, boolean[][] ignore)
-            throws IllegalArgumentException {
+            double[][] latitudes, double[][] times, boolean[][] ignore) throws IllegalArgumentException {
         if ( (expocodes == null) || (expocodes.length != 2) ||
                 (expocodes[0] == null) || (expocodes[1] == null) )
             throw new IllegalArgumentException("Invalid datasetIds given to checkForOverlaps");
@@ -297,25 +297,16 @@ public class OverlapChecker {
                         DashboardUtils.closeTo(latitudes[0][j], latitudes[1][k], 0.0, DsgNcFile.MIN_LAT_DIFF) &&
                         DashboardUtils.longitudeCloseTo(longitudes[0][j], longitudes[1][k],
                                 0.0, DsgNcFile.MIN_LON_DIFF) ) {
-                    if ( swapped ) {
+                    if ( swapped )
                         // swap row number to match datasetIds above
-                        // different expocodes; report first expocode's data point for WOCE-4
-                        oerlap.addDuplicatePoint(k + 1, j + 1, longitudes[0][k], latitudes[0][k], times[0][k]);
-                    }
-                    else if ( sameExpo ) {
-                        // internal overlap; report second occurrence for WOCE-4
-                        oerlap.addDuplicatePoint(j + 1, k + 1, longitudes[0][k], latitudes[0][k], times[0][k]);
-                    }
-                    else {
-                        // different expocodes; report first expocode's data point for WOCE-4
-                        oerlap.addDuplicatePoint(j + 1, k + 1, longitudes[0][j], latitudes[0][j], times[0][j]);
-                    }
+                        oerlap.addDuplicatePoint(k + 1, j + 1, longitudes[1][k], longitudes[0][j],
+                                latitudes[1][k], latitudes[0][j], times[1][k], times[0][j]);
+                    else
+                        oerlap.addDuplicatePoint(j + 1, k + 1, longitudes[0][j], longitudes[1][k],
+                                latitudes[0][j], latitudes[1][k], times[0][j], times[1][k]);
                 }
             }
         }
-
-        if ( oerlap.getLons().isEmpty() )
-            return null;
 
         return oerlap;
     }

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/actions/OverlapChecker.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/actions/OverlapChecker.java
@@ -49,9 +49,10 @@ public class OverlapChecker {
     }
 
     /**
-     * Checks for overlaps between a data set and a collection of other data sets.  Reads the data once for the primary
-     * data set, then reads the data as needed for the other data sets.  Ignores any data points with a {@link
-     * SocatTypes#WOCE_CO2_WATER} value of {@link DashboardServerUtils#WOCE_BAD}.
+     * Checks for overlaps between a data set and a collection of other data sets.  Reads the data once
+     * for the primary data set, then reads the data as needed for the other data sets.  Ignores any
+     * data points with a {@link SocatTypes#WOCE_CO2_WATER} value of {@link DashboardServerUtils#WOCE_BAD}
+     * or where the fCO2_rec value is missing.
      *
      * @param expocode
      *         the expocode of the primary data set to examine
@@ -60,8 +61,8 @@ public class OverlapChecker {
      * @param progressPrinter
      *         if not null, progress messages with timings are printed using this PrintStream
      * @param progStartMilliTime
-     *         System.getCurrentTimeMillis() start time of the program for reporting times to progressWriter; only used
-     *         if progressWriter is not null
+     *         System.getCurrentTimeMillis() start time of the program for reporting times to progressWriter;
+     *         only used if progressPrinter is not null
      *
      * @return the list of overlaps found; never null but may be empty.
      *
@@ -72,9 +73,8 @@ public class OverlapChecker {
      * @throws IOException
      *         if problems reading from any full-data DSG file
      */
-    public ArrayList<Overlap> getOverlaps(String expocode,
-            Iterable<String> checkExpos, PrintStream progressPrinter,
-            long progStartMilliTime)
+    public ArrayList<Overlap> getOverlaps(String expocode, Iterable<String> checkExpos,
+            PrintStream progressPrinter, long progStartMilliTime)
             throws IllegalArgumentException, FileNotFoundException, IOException {
         ArrayList<Overlap> overlapList = new ArrayList<Overlap>();
 
@@ -99,7 +99,7 @@ public class OverlapChecker {
         ignores[0] = new boolean[dataVals[4].length];
         for (int k = 0; k < dataVals[4].length; k++) {
             ignores[0][k] = DashboardUtils.closeTo(dataVals[4][k], DashboardUtils.FP_MISSING_VALUE,
-                    0.0, DashboardUtils.MAX_ABSOLUTE_ERROR);
+                    DashboardUtils.MAX_RELATIVE_ERROR, DashboardUtils.MAX_ABSOLUTE_ERROR);
         }
 
         for (String otherExpo : checkExpos) {
@@ -124,7 +124,7 @@ public class OverlapChecker {
                 ignores[1] = new boolean[dataVals[4].length];
                 for (int k = 0; k < dataVals[4].length; k++) {
                     ignores[1][k] = DashboardUtils.closeTo(dataVals[4][k], DashboardUtils.FP_MISSING_VALUE,
-                            0.0, DashboardUtils.MAX_ABSOLUTE_ERROR);
+                            DashboardUtils.MAX_RELATIVE_ERROR, DashboardUtils.MAX_ABSOLUTE_ERROR);
                 }
             }
 
@@ -156,9 +156,9 @@ public class OverlapChecker {
     }
 
     /**
-     * Reads and returns the longitudes, latitudes, times, SSTs, and fCO2s for the data points in a data set.  The
-     * values for any data points with a {@link SocatTypes#WOCE_CO2_WATER} value of {@link
-     * DashboardServerUtils#WOCE_BAD} are set to {@link DashboardUtils#FP_MISSING_VALUE}.
+     * Reads and returns the longitudes, latitudes, times, SSTs, and fCO2s for the data points
+     * in a data set.  The values for any data points with a {@link SocatTypes#WOCE_CO2_WATER}
+     * value of {@link DashboardServerUtils#WOCE_BAD} are set to {@link DashboardUtils#FP_MISSING_VALUE}.
      *
      * @param upperExpo
      *         get the data from the dataset with this expocode
@@ -252,34 +252,36 @@ public class OverlapChecker {
         boolean sameExpo = expocodes[0].equals(expocodes[1]);
         int kStart = 0;
         for (int j = 0; j < numRows[0]; j++) {
+            // Skip any points already WOCE-4 or with missing fCO2_rec
             if ( ignore[0][j] )
                 continue;
-            // Skip this point if any missing values
+            // Skip this point if missing lon, lat, or time value
             if ( DashboardUtils.closeTo(DashboardUtils.FP_MISSING_VALUE, longitudes[0][j],
-                    0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) )
+                    DashboardUtils.MAX_RELATIVE_ERROR, DashboardUtils.MAX_ABSOLUTE_ERROR) )
                 continue;
             if ( DashboardUtils.closeTo(DashboardUtils.FP_MISSING_VALUE, latitudes[0][j],
-                    0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) )
+                    DashboardUtils.MAX_RELATIVE_ERROR, DashboardUtils.MAX_ABSOLUTE_ERROR) )
                 continue;
             if ( DashboardUtils.closeTo(DashboardUtils.FP_MISSING_VALUE, times[0][j],
-                    0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) )
+                    DashboardUtils.MAX_RELATIVE_ERROR, DashboardUtils.MAX_ABSOLUTE_ERROR) )
                 continue;
 
             if ( sameExpo )
                 kStart = j + 1;
 
             for (int k = kStart; k < numRows[1]; k++) {
+                // Skip any points already WOCE-4 or with missing fCO2_rec
                 if ( ignore[1][k] )
                     continue;
-                // Skip this point if any missing values
+                // Skip this point if missing lon, lat, or time value
                 if ( DashboardUtils.closeTo(DashboardUtils.FP_MISSING_VALUE, longitudes[1][k],
-                        0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) )
+                        DashboardUtils.MAX_RELATIVE_ERROR, DashboardUtils.MAX_ABSOLUTE_ERROR) )
                     continue;
                 if ( DashboardUtils.closeTo(DashboardUtils.FP_MISSING_VALUE, latitudes[1][k],
-                        0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) )
+                        DashboardUtils.MAX_RELATIVE_ERROR, DashboardUtils.MAX_ABSOLUTE_ERROR) )
                     continue;
                 if ( DashboardUtils.closeTo(DashboardUtils.FP_MISSING_VALUE, times[1][k],
-                        0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) )
+                        DashboardUtils.MAX_RELATIVE_ERROR, DashboardUtils.MAX_ABSOLUTE_ERROR) )
                     continue;
 
                 if ( times[1][k] >= times[0][j] + TIME_WINDOW ) {

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/client/DataUploadPage.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/client/DataUploadPage.java
@@ -84,7 +84,7 @@ public class DataUploadPage extends CompositeWithUsername {
                     "  <li>20-01B,110.79910,19042012,19:10:42,12.617,-59.216,...</li>" +
                     "</ul>" +
                     "The 12 character expocode is the " +
-                    "<a href=\"http://www.nodc.noaa.gov/General/NODC-Archive/platformlist.txt\" target=\"_blank\">NODC code</a> " +
+                    "<a href=\"https://www.nodc.noaa.gov/General/NODC-Archive/platformlist.txt\" target=\"_blank\">NODC code</a> " +
                     "for the vessel carrying the instrumentation followed by the " +
                     "numeric year, month, and day of departure.  For example, " +
                     "49P120101218 indicates a cruise on the Japanese (49) ship" +

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/client/OmeManagerPage.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/client/OmeManagerPage.java
@@ -39,18 +39,19 @@ public class OmeManagerPage extends CompositeWithUsername {
     private static final String UPLOAD_TEXT = "Upload";
     private static final String CANCEL_TEXT = "Cancel";
 
-    private static final String CRUISE_HTML_INTRO_PROLOGUE =
-            "<p>At this time, the system only uploads SOCAT OME XML metadata files.</p>" +
-                    "<p>To generate a SOCAT OME XML metadata file to upload: <ul>" +
-                    "<li>Go to the Online Metadata Editor site " +
-                    "<a href=\"http://mercury.ornl.gov/socatome/\" target=\"_blank\">" +
-                    "http://mercury.ornl.gov/socatome/</a></li>" +
-                    "<li>Fill in the appropriate metadata</li>" +
-                    "<li>Save a local copy (preferrably with validation)</li>" +
-                    "</ul>" +
-                    "This will create a SOCAT OME XML metadata file on your system that can be uploaded here. " +
-                    "</p><p>" +
-                    "Dataset: <ul><li>";
+    private static final String CRUISE_HTML_INTRO_PROLOGUE = "<p>" +
+            "At this time, the system only uploads CDIAC-style OME XML metadata files. " +
+            "Unfortunately, the CDIAC Online Metadata Editor no longer exists. " +
+            "A new Online Metadata Editor is being built and tested, but is not available at this time. " +
+            "</p>" +
+            "<p>" +
+            "Please upload whatever metadata files you have as \"Supplemental Documents\". " +
+            "A spreadsheet for providing metadata can be obtained using the \"metadata template\" " +
+            "link on the SOCAT info page at <a href=\"https://www.socat.info/index.php/data-upload-and-quality-control/\" " +
+            "target=\"_blank\">https://www.socat.info/index.php/data-upload-and-quality-control/</a> " +
+            "</p>" +
+            "<p>" +
+            "Dataset: <ul><li>";
     private static final String CRUISE_HTML_INTRO_EPILOGUE = "</li></ul></p>";
 
     private static final String NO_FILE_ERROR_MSG =

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/dsg/DsgNcFile.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/dsg/DsgNcFile.java
@@ -34,7 +34,21 @@ import java.util.TreeSet;
 
 public class DsgNcFile extends File {
 
-    private static final long serialVersionUID = 9104295509280903806L;
+    private static final long serialVersionUID = 6945081126586572333L;
+
+    /**
+     * Minimum time difference, in seconds, for two values to be considered different
+     * Duplicate times in some datases were "fixed" by using fractional seconds, so go to milliseconds.
+     */
+    public static final double MIN_TIME_DIFF = 0.001;
+    /**
+     * Minimum longitude difference, in degrees, for two value to be considered different
+     */
+    public static final double MIN_LON_DIFF = 0.0001;
+    /**
+     * Minimum latitude difference, in degrees, for two value to be considered different
+     */
+    public static final double MIN_LAT_DIFF = 0.0001;
 
     private static final String DSG_VERSION = "DsgNcFile 2.0";
     private static final String TIME_ORIGIN_ATTRIBUTE = "01-JAN-1970 00:00:00";
@@ -1183,16 +1197,16 @@ public class DsgNcFile extends File {
      */
     private boolean dataMatches(DataLocation dataloc, ArrayDouble.D1 longitudes, ArrayDouble.D1 latitudes,
             ArrayDouble.D1 times, ArrayDouble.D1 datavalues, int idx) {
-        // Check if longitude is within 0.001 degrees of each other
-        if ( !DashboardUtils.longitudeCloseTo(dataloc.getLongitude(), longitudes.get(idx), 0.0, 0.001) )
+        // Check if longitudes are close enough (taking modulo 360.0 into account)
+        if ( !DashboardUtils.longitudeCloseTo(dataloc.getLongitude(), longitudes.get(idx), 0.0, MIN_LON_DIFF) )
             return false;
 
-        // Check if latitude is within 0.0001 degrees of each other
-        if ( !DashboardUtils.closeTo(dataloc.getLatitude(), latitudes.get(idx), 0.0, 0.0001) )
+        // Check if latitudes are close enough
+        if ( !DashboardUtils.closeTo(dataloc.getLatitude(), latitudes.get(idx), 0.0, MIN_LAT_DIFF) )
             return false;
 
-        // Check if times are within a second of each other
-        if ( !DashboardUtils.closeTo(dataloc.getDataDate().getTime() / 1000.0, times.get(idx), 0.0, 1.0) )
+        // Check if times are close enough
+        if ( !DashboardUtils.closeTo(dataloc.getDataDate().getTime() / 1000.0, times.get(idx), 0.0, MIN_TIME_DIFF) )
             return false;
 
         // If given, check if data values are close to each other

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/handlers/DsgNcFileHandler.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/handlers/DsgNcFileHandler.java
@@ -595,7 +595,7 @@ public class DsgNcFileHandler {
     }
 
     /**
-     * Updates the full-data DSG file with the given data QC flags, then regenerates the decimated DSG file.
+     * Updates the full-data DSG file with the given data QC flags, and then regenerates the decimated DSG file.
      * Optionally, will also update the row number in the data QC flags from the data in the full-data DSG file.
      *
      * @param woceEvent

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/qc/DataLocation.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/qc/DataLocation.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package gov.noaa.pmel.dashboard.qc;
 
 import gov.noaa.pmel.dashboard.shared.DashboardUtils;
@@ -20,7 +17,6 @@ public class DataLocation implements Comparable<DataLocation> {
     protected Date dataDate;
     protected Double longitude;
     protected Double latitude;
-    protected Double depth;
     protected Double dataValue;
 
     /**
@@ -31,7 +27,6 @@ public class DataLocation implements Comparable<DataLocation> {
         dataDate = DashboardUtils.DATE_MISSING_VALUE;
         longitude = DashboardUtils.FP_MISSING_VALUE;
         latitude = DashboardUtils.FP_MISSING_VALUE;
-        depth = DashboardUtils.FP_MISSING_VALUE;
         dataValue = DashboardUtils.FP_MISSING_VALUE;
     }
 
@@ -118,24 +113,6 @@ public class DataLocation implements Comparable<DataLocation> {
     }
 
     /**
-     * @return the sample depth; never null but may be {@link DashboardUtils#FP_MISSING_VALUE}
-     */
-    public Double getDepth() {
-        return depth;
-    }
-
-    /**
-     * @param depth
-     *         the sample depth to set; if null, {@link DashboardUtils#FP_MISSING_VALUE} is assigned.
-     */
-    public void setDepth(Double depth) {
-        if ( depth == null )
-            this.depth = DashboardUtils.FP_MISSING_VALUE;
-        else
-            this.depth = depth;
-    }
-
-    /**
      * @return the data value; never null but may be {@link DashboardUtils#FP_MISSING_VALUE}
      */
     public Double getDataValue() {
@@ -159,7 +136,6 @@ public class DataLocation implements Comparable<DataLocation> {
      * <li>date</li>
      * <li>longitude</li>
      * <li>latitude</li>
-     * <li>depth</li>
      * <li>data value</li>
      * <li>row number</li>
      * </ol>
@@ -177,9 +153,6 @@ public class DataLocation implements Comparable<DataLocation> {
         if ( result != 0 )
             return result;
         result = latitude.compareTo(other.latitude);
-        if ( result != 0 )
-            return result;
-        result = depth.compareTo(other.depth);
         if ( result != 0 )
             return result;
         result = dataValue.compareTo(other.dataValue);
@@ -219,8 +192,6 @@ public class DataLocation implements Comparable<DataLocation> {
         if ( !DashboardUtils.closeTo(dataValue, other.dataValue,
                 DashboardUtils.MAX_RELATIVE_ERROR, DashboardUtils.MAX_ABSOLUTE_ERROR) )
             return false;
-        if ( !DashboardUtils.closeTo(depth, other.depth, 0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) )
-            return false;
         if ( !DashboardUtils.closeTo(latitude, other.latitude, 0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) )
             return false;
         if ( !DashboardUtils.longitudeCloseTo(longitude, other.longitude, 0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) )
@@ -236,7 +207,6 @@ public class DataLocation implements Comparable<DataLocation> {
                 ", dataTime=" + Long.toString(Math.round((dataDate.getTime() / 1000.0))) +
                 ", longitude=" + longitude.toString() +
                 ", latitude=" + latitude.toString() +
-                ", depth=" + depth.toString() +
                 ", dataValue=" + dataValue.toString() +
                 "]";
     }
@@ -257,9 +227,6 @@ public class DataLocation implements Comparable<DataLocation> {
             if ( result != 0 )
                 return result;
             result = first.latitude.compareTo(second.latitude);
-            if ( result != 0 )
-                return result;
-            result = first.depth.compareTo(second.depth);
             if ( result != 0 )
                 return result;
             result = first.dataValue.compareTo(second.dataValue);

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/server/DashboardServerUtils.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/server/DashboardServerUtils.java
@@ -600,7 +600,8 @@ public class DashboardServerUtils {
         double maxVal = DashboardUtils.FP_MISSING_VALUE;
         double minVal = DashboardUtils.FP_MISSING_VALUE;
         for (double val : data) {
-            if ( DashboardUtils.closeTo(DashboardUtils.FP_MISSING_VALUE, val, 0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) )
+            if ( DashboardUtils.closeTo(DashboardUtils.FP_MISSING_VALUE, val,
+                    DashboardUtils.MAX_RELATIVE_ERROR, DashboardUtils.MAX_ABSOLUTE_ERROR) )
                 continue;
             if ( (maxVal == DashboardUtils.FP_MISSING_VALUE) || (minVal == DashboardUtils.FP_MISSING_VALUE) ) {
                 maxVal = val;

--- a/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/shared/Overlap.java
+++ b/UploadDashboard/src/main/java/gov/noaa/pmel/dashboard/shared/Overlap.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package gov.noaa.pmel.dashboard.shared;
 
 import com.google.gwt.user.client.rpc.IsSerializable;
@@ -10,23 +7,23 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 /**
- * Overlaps are duplications of location and time values either within a dataset or between any two datasets.
- * Extensive overlaps are very likely to be erroneous duplication of data, although there is the rare possibility
- * of two instruments on the same platform.
+ * Overlaps are duplications of location and time values either within a dataset or between
+ * any two datasets.  Extensive overlaps are very likely to be erroneous duplication of data,
+ * although there is the rare possibility of two instruments on the same platform.
  * <p>
- * (This is in the shared package for future enhancements where the dashboard reports overlaps.)
+ * This is in the shared package for future enhancements where the dashboard reports overlaps.
  *
  * @author Karl Smith
  */
 public class Overlap implements Serializable, IsSerializable, Comparable<Overlap> {
 
-    private static final long serialVersionUID = 8793295231128742822L;
+    private static final long serialVersionUID = -7415369842909141943L;
 
     protected String[] datasetIds;
     protected ArrayList<Integer>[] rowNums;
-    protected ArrayList<Double> lons;
-    protected ArrayList<Double> lats;
-    protected ArrayList<Double> times;
+    protected ArrayList<Double>[] lons;
+    protected ArrayList<Double>[] lats;
+    protected ArrayList<Double>[] times;
 
     /**
      * Creates an overlap with no information (all empty).
@@ -96,7 +93,7 @@ public class Overlap implements Serializable, IsSerializable, Comparable<Overlap
     /**
      * @return the dataset row numbers (starts with one) of the overlap;
      *         always an array of two ArrayLists, but the ArrayLists may be empty.
-     *         The actual array in this instance is returned.
+     *         The actual array of ArrayLists in this instance is returned.
      */
     public ArrayList<Integer>[] getRowNums() {
         return rowNums;
@@ -124,66 +121,92 @@ public class Overlap implements Serializable, IsSerializable, Comparable<Overlap
     }
 
     /**
-     * @return the longitudes of the overlap; never null but may be empty.
-     *         The actual ArrayList in this instance is returned.
+     * @return the longitudes of the overlap;
+     *         always an array of two ArrayLists, but the ArrayLists may be empty.
+     *         The actual array of ArrayLists in this instance is returned.
      */
-    public ArrayList<Double> getLons() {
+    public ArrayList<Double>[] getLons() {
         return lons;
     }
 
     /**
      * @param lons
-     *         the longitudes of the overlap to set. If null, an empty ArrayList is assigned.
+     *         the longitudes of the overlap to set.
+     *         If null, an array of two empty ArrayLists is assigned;
+     *         otherwise an array of two Double ArrayLists of the same length must be given.
      */
-    public void setLons(ArrayList<Double> lons) {
+    @SuppressWarnings("unchecked")
+    public void setLons(ArrayList<Double>[] lons) {
         if ( lons == null ) {
-            this.lons = new ArrayList<Double>();
+            this.lons = new ArrayList[] { new ArrayList<Double>(), new ArrayList<Double>() };
         }
         else {
-            this.lons = new ArrayList<Double>(lons);
+            if ( lons.length != 2 )
+                throw new IllegalArgumentException("lons array not length 2");
+            if ( lons[0].size() != lons[1].size() )
+                throw new IllegalArgumentException("lons arrays not same length");
+            this.lons[0] = new ArrayList<Double>(lons[0]);
+            this.lons[1] = new ArrayList<Double>(lons[1]);
         }
     }
 
     /**
-     * @return the latitudes of the overlap; never null but may be empty.
-     *         The actual ArrayList in this instance is returned.
+     * @return the latitudes of the overlap;
+     *         always an array of two ArrayLists, but the ArrayLists may be empty.
+     *         The actual array of ArrayLists in this instance is returned.
      */
-    public ArrayList<Double> getLats() {
+    public ArrayList<Double>[] getLats() {
         return lats;
     }
 
     /**
      * @param lats
-     *         the latitudes of the overlap to set.  If null, an empty ArrayList is assigned.
+     *         the latitudes of the overlap to set.
+     *         If null, an array of two empty ArrayLists is assigned;
+     *         otherwise an array of two Double ArrayLists of the same length must be given.
      */
-    public void setLats(ArrayList<Double> lats) {
+    @SuppressWarnings("unchecked")
+    public void setLats(ArrayList<Double>[] lats) {
         if ( lats == null ) {
-            this.lats = new ArrayList<Double>();
+            this.lats = new ArrayList[] { new ArrayList<Double>(), new ArrayList<Double>() };
         }
         else {
-            this.lats = new ArrayList<Double>(lats);
+            if ( lats.length != 2 )
+                throw new IllegalArgumentException("lats array not length 2");
+            if ( lats[0].size() != lats[1].size() )
+                throw new IllegalArgumentException("lats arrays not same length");
+            this.lats[0] = new ArrayList<Double>(lats[0]);
+            this.lats[1] = new ArrayList<Double>(lats[1]);
         }
     }
 
     /**
-     * @return the times, in seconds since 1 JAN 1970 00:00:00, of the overlap; never null but may be empty.
-     *         The actual ArrayList in this instance is returned.
+     * @return the times, in seconds since 1 JAN 1970 00:00:00, of the overlap;
+     *         always an array of two ArrayLists, but the ArrayLists may be empty.
+     *         The actual array of ArrayLists in this instance is returned.
      */
-    public ArrayList<Double> getTimes() {
+    public ArrayList<Double>[] getTimes() {
         return times;
     }
 
     /**
      * @param times
      *         the times, in seconds since 1 JAN 1970 00:00:00, of the overlap to set.
-     *         If null, an empty ArrayList assigned.
+     *         If null, an array of two empty ArrayLists is assigned;
+     *         otherwise an array of two Double ArrayLists of the same length must be given.
      */
-    public void setTimes(ArrayList<Double> times) {
+    @SuppressWarnings("unchecked")
+    public void setTimes(ArrayList<Double>[] times) {
         if ( times == null ) {
-            this.times = new ArrayList<Double>();
+            this.times = new ArrayList[] { new ArrayList<Double>(), new ArrayList<Double>() };
         }
         else {
-            this.times = new ArrayList<Double>(times);
+            if ( times.length != 2 )
+                throw new IllegalArgumentException("times array not length 2");
+            if ( times[0].size() != times[1].size() )
+                throw new IllegalArgumentException("times arrays not same length");
+            this.times[0] = new ArrayList<Double>(times[0]);
+            this.times[1] = new ArrayList<Double>(times[1]);
         }
     }
 
@@ -194,19 +217,39 @@ public class Overlap implements Serializable, IsSerializable, Comparable<Overlap
      *         row number (starts with one) of the overlap data point in the first dataset
      * @param secondRowNum
      *         row number (starts with one) of the overlap data point in the second dataset
-     * @param longitude
-     *         longitude of the overlap data point in the datasets
-     * @param latitude
-     *         latitude of the overlap data point in the datasets
-     * @param time
-     *         time, in seconds since 1 JAN 1970 00:00:00, of the overlap data point in the datasets
+     * @param firstLon
+     *         longitude of the overlap data point in the the first dataset
+     * @param secondLon
+     *         longitude of the overlap data point in the the second dataset
+     * @param firstLat
+     *         latitude of the overlap data point in the first dataset
+     * @param secondLat
+     *         latitude of the overlap data point in the second dataset
+     * @param firstTime
+     *         time, in seconds since 1 JAN 1970 00:00:00, of the overlap data point in the first dataset
+     * @param secondTime
+     *         time, in seconds since 1 JAN 1970 00:00:00, of the overlap data point in the second dataset
      */
-    public void addDuplicatePoint(int firstRowNum, int secondRowNum, double longitude, double latitude, double time) {
+    public void addDuplicatePoint(int firstRowNum, int secondRowNum, double firstLon, double secondLon,
+            double firstLat, double secondLat, double firstTime, double secondTime) {
         rowNums[0].add(firstRowNum);
         rowNums[1].add(secondRowNum);
-        lons.add(longitude);
-        lats.add(latitude);
-        times.add(time);
+        lons[0].add(firstLon);
+        lons[1].add(secondLon);
+        lats[0].add(firstLat);
+        lats[1].add(secondLat);
+        times[0].add(firstTime);
+        times[1].add(secondTime);
+    }
+
+    /**
+     * @return true if this overlap does not contain any points
+     */
+    public boolean isEmpty() {
+        return (rowNums[0].isEmpty() && rowNums[1].isEmpty() &&
+                lons[0].isEmpty() && lons[1].isEmpty() &&
+                lats[0].isEmpty() && lats[1].isEmpty() &&
+                times[0].isEmpty() && times[1].isEmpty());
     }
 
     @Override
@@ -228,13 +271,22 @@ public class Overlap implements Serializable, IsSerializable, Comparable<Overlap
         result = Integer.compare(rowNums[1].size(), other.rowNums[1].size());
         if ( result != 0 )
             return result;
-        result = Integer.compare(times.size(), other.times.size());
+        result = Integer.compare(times[0].size(), other.times[0].size());
         if ( result != 0 )
             return result;
-        result = Integer.compare(lats.size(), other.lats.size());
+        result = Integer.compare(times[1].size(), other.times[1].size());
         if ( result != 0 )
             return result;
-        result = Integer.compare(lons.size(), other.lons.size());
+        result = Integer.compare(lats[0].size(), other.lats[0].size());
+        if ( result != 0 )
+            return result;
+        result = Integer.compare(lats[1].size(), other.lats[1].size());
+        if ( result != 0 )
+            return result;
+        result = Integer.compare(lons[0].size(), other.lons[0].size());
+        if ( result != 0 )
+            return result;
+        result = Integer.compare(lons[1].size(), other.lons[1].size());
         if ( result != 0 )
             return result;
 
@@ -257,22 +309,40 @@ public class Overlap implements Serializable, IsSerializable, Comparable<Overlap
             if ( result != 0 )
                 return result;
         }
-        for (int k = 0; k < times.size(); k++) {
-            if ( !DashboardUtils.closeTo(times.get(k), other.times.get(k),
+        for (int k = 0; k < times[0].size(); k++) {
+            if ( !DashboardUtils.closeTo(times[0].get(k), other.times[0].get(k),
                     0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) ) {
-                return times.get(k).compareTo(other.times.get(k));
+                return times[0].get(k).compareTo(other.times[0].get(k));
             }
         }
-        for (int k = 0; k < lats.size(); k++) {
-            if ( !DashboardUtils.closeTo(lats.get(k), other.lats.get(k),
+        for (int k = 0; k < times[1].size(); k++) {
+            if ( !DashboardUtils.closeTo(times[1].get(k), other.times[1].get(k),
                     0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) ) {
-                return lats.get(k).compareTo(other.lats.get(k));
+                return times[1].get(k).compareTo(other.times[1].get(k));
             }
         }
-        for (int k = 0; k < lons.size(); k++) {
-            if ( !DashboardUtils.longitudeCloseTo(lons.get(k), other.lons.get(k),
+        for (int k = 0; k < lats[0].size(); k++) {
+            if ( !DashboardUtils.closeTo(lats[0].get(k), other.lats[0].get(k),
                     0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) ) {
-                return lons.get(k).compareTo(other.lons.get(k));
+                return lats[0].get(k).compareTo(other.lats[0].get(k));
+            }
+        }
+        for (int k = 0; k < lats[1].size(); k++) {
+            if ( !DashboardUtils.closeTo(lats[1].get(k), other.lats[1].get(k),
+                    0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) ) {
+                return lats[1].get(k).compareTo(other.lats[1].get(k));
+            }
+        }
+        for (int k = 0; k < lons[0].size(); k++) {
+            if ( !DashboardUtils.longitudeCloseTo(lons[0].get(k), other.lons[0].get(k),
+                    0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) ) {
+                return lons[0].get(k).compareTo(other.lons[0].get(k));
+            }
+        }
+        for (int k = 0; k < lons[1].size(); k++) {
+            if ( !DashboardUtils.longitudeCloseTo(lons[1].get(k), other.lons[1].get(k),
+                    0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) ) {
+                return lons[1].get(k).compareTo(other.lons[1].get(k));
             }
         }
 
@@ -286,9 +356,12 @@ public class Overlap implements Serializable, IsSerializable, Comparable<Overlap
         result = prime * result + Arrays.hashCode(rowNums);
         // Do not include floating point values, as they do not have to be exact to match
         // but do include the number of floating point values as those do have to match
-        result = prime * result + Integer.hashCode(times.size());
-        result = prime * result + Integer.hashCode(lats.size());
-        result = prime * result + Integer.hashCode(lons.size());
+        result = prime * result + Integer.hashCode(times[0].size());
+        result = prime * result + Integer.hashCode(times[1].size());
+        result = prime * result + Integer.hashCode(lats[0].size());
+        result = prime * result + Integer.hashCode(lats[1].size());
+        result = prime * result + Integer.hashCode(lons[0].size());
+        result = prime * result + Integer.hashCode(lons[1].size());
 
         return result;
     }
@@ -307,11 +380,17 @@ public class Overlap implements Serializable, IsSerializable, Comparable<Overlap
 
         Overlap other = (Overlap) obj;
 
-        if ( times.size() != other.times.size() )
+        if ( times[0].size() != other.times[0].size() )
             return false;
-        if ( lats.size() != other.lats.size() )
+        if ( times[1].size() != other.times[1].size() )
             return false;
-        if ( lons.size() != other.lons.size() )
+        if ( lats[0].size() != other.lats[0].size() )
+            return false;
+        if ( lats[1].size() != other.lats[1].size() )
+            return false;
+        if ( lons[0].size() != other.lons[0].size() )
+            return false;
+        if ( lons[1].size() != other.lons[1].size() )
             return false;
 
         if ( !Arrays.equals(datasetIds, other.datasetIds) )
@@ -319,20 +398,38 @@ public class Overlap implements Serializable, IsSerializable, Comparable<Overlap
         if ( !Arrays.equals(rowNums, other.rowNums) )
             return false;
 
-        for (int k = 0; k < times.size(); k++) {
-            if ( !DashboardUtils.closeTo(times.get(k), other.times.get(k),
+        for (int k = 0; k < times[0].size(); k++) {
+            if ( !DashboardUtils.closeTo(times[0].get(k), other.times[0].get(k),
                     0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) ) {
                 return false;
             }
         }
-        for (int k = 0; k < lats.size(); k++) {
-            if ( !DashboardUtils.closeTo(lats.get(k), other.lats.get(k),
+        for (int k = 0; k < times[1].size(); k++) {
+            if ( !DashboardUtils.closeTo(times[1].get(k), other.times[1].get(k),
                     0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) ) {
                 return false;
             }
         }
-        for (int k = 0; k < lons.size(); k++) {
-            if ( !DashboardUtils.longitudeCloseTo(lons.get(k), other.lons.get(k),
+        for (int k = 0; k < lats[0].size(); k++) {
+            if ( !DashboardUtils.closeTo(lats[0].get(k), other.lats[0].get(k),
+                    0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) ) {
+                return false;
+            }
+        }
+        for (int k = 0; k < lats[1].size(); k++) {
+            if ( !DashboardUtils.closeTo(lats[1].get(k), other.lats[1].get(k),
+                    0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) ) {
+                return false;
+            }
+        }
+        for (int k = 0; k < lons[0].size(); k++) {
+            if ( !DashboardUtils.longitudeCloseTo(lons[0].get(k), other.lons[0].get(k),
+                    0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) ) {
+                return false;
+            }
+        }
+        for (int k = 0; k < lons[1].size(); k++) {
+            if ( !DashboardUtils.longitudeCloseTo(lons[1].get(k), other.lons[1].get(k),
                     0.0, DashboardUtils.MAX_ABSOLUTE_ERROR) ) {
                 return false;
             }
@@ -346,9 +443,9 @@ public class Overlap implements Serializable, IsSerializable, Comparable<Overlap
         return "Overlap" +
                 "[ datasetIds=" + Arrays.toString(datasetIds) +
                 ", rowNums=" + Arrays.toString(rowNums) +
-                ", lons=" + lons.toString() +
-                ", lats=" + lats.toString() +
-                ", times=" + times.toString() +
+                ", lons=" + Arrays.toString(lons) +
+                ", lats=" + Arrays.toString(lats) +
+                ", times=" + Arrays.toString(times) +
                 "]";
     }
 

--- a/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/qc/DataLocationTest.java
+++ b/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/qc/DataLocationTest.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package gov.noaa.pmel.dashboard.test.qc;
 
 import gov.noaa.pmel.dashboard.qc.DataLocation;
@@ -26,7 +23,6 @@ public class DataLocationTest {
     private static final Date MY_DATA_DATE = new Date(3458139048000L);
     private static final Double MY_LONGITUDE = -179.45;
     private static final Double MY_LATITUDE = -2.65;
-    private static final Double MY_DEPTH = 50.0;
     private static final Double MY_DATA_VALUE = 1002.97;
 
     /**
@@ -85,23 +81,6 @@ public class DataLocationTest {
         assertEquals(DashboardUtils.INT_MISSING_VALUE, myflag.getRowNumber());
         myflag.setLatitude(null);
         assertEquals(DashboardUtils.FP_MISSING_VALUE, myflag.getLatitude());
-    }
-
-    /**
-     * Test method for {@link DataLocation#getDepth()} and {@link DataLocation#setDepth(Double)}.
-     */
-    @Test
-    public void testGetSetDepth() {
-        DataLocation myflag = new DataLocation();
-        assertEquals(DashboardUtils.FP_MISSING_VALUE, myflag.getDepth());
-        myflag.setDepth(MY_DEPTH);
-        assertEquals(MY_DEPTH, myflag.getDepth());
-        assertEquals(DashboardUtils.FP_MISSING_VALUE, myflag.getLatitude());
-        assertEquals(DashboardUtils.FP_MISSING_VALUE, myflag.getLongitude());
-        assertEquals(DashboardUtils.DATE_MISSING_VALUE, myflag.getDataDate());
-        assertEquals(DashboardUtils.INT_MISSING_VALUE, myflag.getRowNumber());
-        myflag.setDepth(null);
-        assertEquals(DashboardUtils.FP_MISSING_VALUE, myflag.getDepth());
     }
 
     /**

--- a/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/qc/DataQCEventTest.java
+++ b/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/qc/DataQCEventTest.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package gov.noaa.pmel.dashboard.test.qc;
 
 import gov.noaa.pmel.dashboard.qc.DataLocation;
@@ -46,7 +43,6 @@ public class DataQCEventTest {
         loc.setDataDate(new Date(3458139048000L));
         loc.setLongitude(-179.5);
         loc.setLatitude(3.5);
-        loc.setDepth(5.0);
         loc.setDataValue(1105.450);
         MY_LOCATIONS.add(loc);
         loc = new DataLocation();
@@ -54,7 +50,6 @@ public class DataQCEventTest {
         loc.setDataDate(new Date(3458139203000L));
         loc.setLongitude(-179.6);
         loc.setLatitude(3.4);
-        loc.setDepth(7.5);
         loc.setDataValue(1105.453);
         MY_LOCATIONS.add(loc);
     }

--- a/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/shared/OverlapTest.java
+++ b/UploadDashboard/src/test/java/gov/noaa/pmel/dashboard/test/shared/OverlapTest.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package gov.noaa.pmel.dashboard.test.shared;
 
 import gov.noaa.pmel.dashboard.shared.Overlap;
@@ -89,15 +86,19 @@ public class OverlapTest {
     /**
      * Test method for {@link Overlap#getLons} and {@link Overlap#setLons}.
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testGetSetLons() {
         Overlap olap = new Overlap();
-        ArrayList<Double> mylons = olap.getLons();
-        assertEquals(0, mylons.size());
+        ArrayList<Double>[] mylons = olap.getLons();
+        assertEquals(2, mylons.length);
+        assertEquals(0, mylons[0].size());
+        assertEquals(0, mylons[1].size());
 
-        olap.setLons(lons);
-        mylons = olap.getLons();
-        assertEquals(lons, mylons);
+        olap.setLons(new ArrayList[] { lons, lons });
+        assertEquals(2, mylons.length);
+        assertEquals(lons, mylons[0]);
+        assertEquals(lons, mylons[1]);
 
         ArrayList<Integer>[] rowNums = olap.getRowNums();
         assertEquals(2, rowNums.length);
@@ -111,24 +112,33 @@ public class OverlapTest {
 
         olap.setLons(null);
         mylons = olap.getLons();
-        assertEquals(0, mylons.size());
+        assertEquals(2, mylons.length);
+        assertEquals(0, mylons[0].size());
+        assertEquals(0, mylons[1].size());
     }
 
     /**
      * Test method for {@link Overlap#getLats} and {@link Overlap#setLats}.
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testGetSetLats() {
         Overlap olap = new Overlap();
-        ArrayList<Double> mylats = olap.getLats();
-        assertEquals(0, mylats.size());
+        ArrayList<Double>[] mylats = olap.getLats();
+        assertEquals(2, mylats.length);
+        assertEquals(0, mylats[0].size());
+        assertEquals(0, mylats[1].size());
 
-        olap.setLats(lats);
+        olap.setLats(new ArrayList[] { lats, lats });
         mylats = olap.getLats();
-        assertEquals(lats, mylats);
+        assertEquals(2, mylats.length);
+        assertEquals(lats, mylats[0]);
+        assertEquals(lats, mylats[1]);
 
-        ArrayList<Double> mylons = olap.getLons();
-        assertEquals(0, mylons.size());
+        ArrayList<Double>[] mylons = olap.getLons();
+        assertEquals(2, mylons.length);
+        assertEquals(0, mylons[0].size());
+        assertEquals(0, mylons[1].size());
 
         ArrayList<Integer>[] rowNums = olap.getRowNums();
         assertEquals(2, rowNums.length);
@@ -142,27 +152,38 @@ public class OverlapTest {
 
         olap.setLats(null);
         mylats = olap.getLats();
-        assertEquals(0, mylats.size());
+        assertEquals(2, mylats.length);
+        assertEquals(0, mylats[0].size());
+        assertEquals(0, mylats[1].size());
     }
 
     /**
      * Test method for {@link Overlap#getTimes} and {@link Overlap#setTimes}.
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testGetSetTimes() {
         Overlap olap = new Overlap();
-        ArrayList<Double> mytimes = olap.getTimes();
-        assertEquals(0, mytimes.size());
+        ArrayList<Double>[] mytimes = olap.getTimes();
+        assertEquals(2, mytimes.length);
+        assertEquals(0, mytimes[0].size());
+        assertEquals(0, mytimes[1].size());
 
-        olap.setTimes(times);
+        olap.setTimes(new ArrayList[] { times, times });
         mytimes = olap.getTimes();
-        assertEquals(times, mytimes);
+        assertEquals(2, mytimes.length);
+        assertEquals(times, mytimes[0]);
+        assertEquals(times, mytimes[1]);
 
-        ArrayList<Double> mylats = olap.getLats();
-        assertEquals(0, mylats.size());
+        ArrayList<Double>[] mylats = olap.getLats();
+        assertEquals(2, mylats.length);
+        assertEquals(0, mylats[0].size());
+        assertEquals(0, mylats[1].size());
 
-        ArrayList<Double> mylons = olap.getLons();
-        assertEquals(0, mylons.size());
+        ArrayList<Double>[] mylons = olap.getLons();
+        assertEquals(2, mylons.length);
+        assertEquals(0, mylons[0].size());
+        assertEquals(0, mylons[1].size());
 
         ArrayList<Integer>[] rowNums = olap.getRowNums();
         assertEquals(2, rowNums.length);
@@ -176,7 +197,42 @@ public class OverlapTest {
 
         olap.setTimes(null);
         mytimes = olap.getTimes();
-        assertEquals(0, mytimes.size());
+        assertEquals(2, mytimes.length);
+        assertEquals(0, mytimes[0].size());
+        assertEquals(0, mytimes[1].size());
+    }
+
+    /**
+     * Test method for {@link Overlap#isEmpty()}.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testIsEmpty() {
+        Overlap oerlap = new Overlap();
+        assertTrue(oerlap.isEmpty());
+
+        oerlap = new Overlap(firstExpo, secondExpo);
+        assertTrue(oerlap.isEmpty());
+
+        oerlap.addDuplicatePoint(firstRowNums.get(0), secondRowNums.get(0),
+                lons.get(0), lons.get(0), lats.get(0), lats.get(0), times.get(0), times.get(0));
+        assertFalse(oerlap.isEmpty());
+
+        oerlap = new Overlap(firstExpo, secondExpo);
+        oerlap.setRowNums(new ArrayList[] { firstRowNums, secondRowNums });
+        assertFalse(oerlap.isEmpty());
+
+        oerlap = new Overlap(firstExpo, secondExpo);
+        oerlap.setLons(new ArrayList[] { lons, lons });
+        assertFalse(oerlap.isEmpty());
+
+        oerlap = new Overlap(firstExpo, secondExpo);
+        oerlap.setLats(new ArrayList[] { lats, lats });
+        assertFalse(oerlap.isEmpty());
+
+        oerlap = new Overlap(firstExpo, secondExpo);
+        oerlap.setTimes(new ArrayList[] { times, times });
+        assertFalse(oerlap.isEmpty());
     }
 
     /**
@@ -207,26 +263,26 @@ public class OverlapTest {
         assertEquals(first.hashCode(), second.hashCode());
         assertTrue(first.equals(second));
 
-        first.setLons(lons);
+        first.setLons(new ArrayList[] { lons, lons });
         // hashCode ignores floating-point values but pays attention to the number of values
         assertNotEquals(first.hashCode(), second.hashCode());
         assertFalse(first.equals(second));
-        second.setLons(lons);
+        second.setLons(new ArrayList[] { lons, lons });
         assertEquals(first.hashCode(), second.hashCode());
         assertTrue(first.equals(second));
 
-        first.setLats(lats);
+        first.setLats(new ArrayList[] { lats, lats });
         // hashCode ignores floating-point values but pays attention to the number of values
         assertNotEquals(first.hashCode(), second.hashCode());
         assertFalse(first.equals(second));
-        second.setLats(lats);
+        second.setLats(new ArrayList[] { lats, lats });
         assertEquals(first.hashCode(), second.hashCode());
         assertTrue(first.equals(second));
 
-        first.setTimes(times);
+        first.setTimes(new ArrayList[] { times, times });
         assertNotEquals(first.hashCode(), second.hashCode());
         assertFalse(first.equals(second));
-        second.setTimes(times);
+        second.setTimes(new ArrayList[] { times, times });
         assertEquals(first.hashCode(), second.hashCode());
         assertTrue(first.equals(second));
     }
@@ -240,14 +296,14 @@ public class OverlapTest {
         Overlap first = new Overlap();
         first.setDatasetIds(new String[] { firstExpo, secondExpo });
         first.setRowNums(new ArrayList[] { firstRowNums, secondRowNums });
-        first.setLats(lats);
-        first.setLons(lons);
-        first.setTimes(times);
+        first.setLons(new ArrayList[] { lons, lons });
+        first.setLats(new ArrayList[] { lats, lats });
+        first.setTimes(new ArrayList[] { times, times });
 
         Overlap second = new Overlap(firstExpo, secondExpo);
         for (int k = 0; k < firstRowNums.size(); k++) {
             second.addDuplicatePoint(firstRowNums.get(k), secondRowNums.get(k),
-                    lons.get(k), lats.get(k), times.get(k));
+                    lons.get(k), lons.get(k), lats.get(k), lats.get(k), times.get(k), times.get(k));
         }
 
         assertEquals(first, second);
@@ -267,7 +323,8 @@ public class OverlapTest {
         assertTrue(first.compareTo(second) < 0);
         second = new Overlap(secondExpo, firstExpo);
         assertTrue(first.compareTo(second) < 0);
-        second.addDuplicatePoint(firstRowNums.get(0), secondRowNums.get(0), lons.get(0), lats.get(0), times.get(0));
+        second.addDuplicatePoint(firstRowNums.get(0), secondRowNums.get(0),
+                lons.get(0), lons.get(0), lats.get(0), lats.get(0), times.get(0), times.get(0));
         assertTrue(first.compareTo(second) < 0);
         second = new Overlap(secondExpo, secondExpo);
         assertEquals(firstExpo.compareTo(secondExpo), first.compareTo(second));
@@ -276,12 +333,15 @@ public class OverlapTest {
         second = new Overlap(secondExpo, firstExpo);
         assertEquals(firstExpo.compareTo(secondExpo), first.compareTo(second));
 
-        first.addDuplicatePoint(firstRowNums.get(0), secondRowNums.get(0), lons.get(0), lats.get(0), times.get(0));
+        first.addDuplicatePoint(firstRowNums.get(0), secondRowNums.get(0),
+                lons.get(0), lons.get(0), lats.get(0), lats.get(0), times.get(0), times.get(0));
         assertTrue(first.compareTo(second) > 0);
         assertTrue(second.compareTo(first) < 0);
 
-        second.addDuplicatePoint(firstRowNums.get(0), secondRowNums.get(0), lons.get(0), lats.get(0), times.get(0));
-        second.addDuplicatePoint(firstRowNums.get(1), secondRowNums.get(1), lons.get(1), lats.get(1), times.get(1));
+        second.addDuplicatePoint(firstRowNums.get(0), secondRowNums.get(0),
+                lons.get(0), lons.get(0), lats.get(0), lats.get(0), times.get(0), times.get(0));
+        second.addDuplicatePoint(firstRowNums.get(1), secondRowNums.get(1),
+                lons.get(1), lons.get(1), lats.get(1), lats.get(1), times.get(1), times.get(1));
         assertTrue(first.compareTo(second) < 0);
         assertTrue(second.compareTo(first) > 0);
 
@@ -289,7 +349,7 @@ public class OverlapTest {
         assertTrue(first.compareTo(second) > 0);
         assertTrue(second.compareTo(first) < 0);
         second.addDuplicatePoint(firstRowNums.get(0), secondRowNums.get(0),
-                lons.get(0) + 360.0, lats.get(0) + 1.0E-8, times.get(0));
+                lons.get(0), lons.get(0) + 360.0, lats.get(0), lats.get(0) + 1.0E-8, times.get(0), times.get(0));
         assertEquals(0, first.compareTo(second));
         assertEquals(0, second.compareTo(first));
     }


### PR DESCRIPTION
Client pages - fixed links and messages on the dataset upload and OME pages.
Overlap object - keep both sets on lon/lat/time
DataLocation object - remove depth (not actually used)
Improved duplicate/overlap reporting and WOCE-4 assignment.  User provided max acceptable fCO2_rec diff between duplicated data points.  Ignore those with missing fCO2_rec as they will be given a "WOCE" flag of "9" (missing).